### PR TITLE
(DO NOT MERGE) LPS-112628 Replaces div class='container*' with clay:container in JSPs

### DIFF
--- a/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/add_channel.jsp
+++ b/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/add_channel.jsp
@@ -33,7 +33,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(resourceBundle, "
 
 <portlet:actionURL name="/analytics/add_channel" var="addChannelURL" />
 
-<div class="container-fluid container-fluid-max-xl">
+<clay:container>
 	<clay:row>
 		<clay:col
 			size="12"
@@ -48,7 +48,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(resourceBundle, "
 			</div>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>
 
 <aui:form action="<%= addChannelURL %>" method="post" name="fm">
 	<aui:input name="redirect" type="hidden" value="<%= redirect %>" />

--- a/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_channel.jsp
+++ b/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_channel.jsp
@@ -36,7 +36,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(resourceBundle, "
 
 <portlet:actionURL name="/analytics/edit_channel" var="editChannelURL" />
 
-<div class="container-fluid container-fluid-max-xl">
+<clay:container>
 	<clay:row>
 		<clay:col
 			size="12"
@@ -51,7 +51,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(resourceBundle, "
 			</div>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>
 
 <aui:form action="<%= editChannelURL %>" method="post" name="fm">
 	<aui:input name="redirect" type="hidden" value="<%= redirect %>" />

--- a/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_synced_contacts_groups.jsp
+++ b/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_synced_contacts_groups.jsp
@@ -33,7 +33,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(resourceBundle, "
 
 <portlet:actionURL name="/analytics/edit_synced_contacts" var="editSyncedContactsURL" />
 
-<div class="container-fluid container-fluid-max-xl">
+<clay:container>
 	<clay:row>
 		<clay:col
 			size="12"
@@ -48,7 +48,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(resourceBundle, "
 			</div>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>
 
 <div class="sheet sheet-lg">
 	<h2 class="autofit-row">

--- a/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_synced_contacts_organizations.jsp
+++ b/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_synced_contacts_organizations.jsp
@@ -33,7 +33,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(resourceBundle, "
 
 <portlet:actionURL name="/analytics/edit_synced_contacts" var="editSyncedContactsURL" />
 
-<div class="container-fluid container-fluid-max-xl">
+<clay:container>
 	<clay:row>
 		<clay:col
 			size="12"
@@ -48,7 +48,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(resourceBundle, "
 			</div>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>
 
 <div class="sheet sheet-lg">
 	<h2 class="autofit-row">

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry_content_detail.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry_content_detail.jsp
@@ -42,7 +42,9 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 			</c:choose>
 		</portlet:renderURL>
 
-		<div class="container widget-mode-detail-header">
+		<clay:container
+			className="widget-mode-detail-header"
+		>
 			<liferay-asset:asset-categories-available
 				className="<%= BlogsEntry.class.getName() %>"
 				classPK="<%= entry.getEntryId() %>"
@@ -153,7 +155,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 					</div>
 				</clay:col>
 			</clay:row>
-		</div>
+		</clay:container>
 
 		<%
 		String coverImageURL = entry.getCoverImageURL(themeDisplay);
@@ -165,7 +167,10 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 
 		<!-- text resume -->
 
-		<div class="container widget-mode-detail-header" id="<portlet:namespace /><%= entry.getEntryId() %>">
+		<clay:container
+			className="widget-mode-detail-header"
+			id="<%= renderResponse.getNamespace() + entry.getEntryId() %>""
+		>
 			<c:if test="<%= Validator.isNotNull(coverImageURL) %>">
 
 				<%
@@ -232,9 +237,9 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 					</clay:col>
 				</clay:row>
 			</liferay-asset:asset-tags-available>
-		</div>
+		</clay:container>
 
-		<div class="container">
+		<clay:container>
 			<clay:row>
 				<clay:col
 					className="mx-auto widget-mode-detail-text"
@@ -272,7 +277,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 					</clay:col>
 				</clay:row>
 			</c:if>
-		</div>
+		</clay:container>
 	</c:when>
 	<c:otherwise>
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/ddm/edit_ddm_structure.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/ddm/edit_ddm_structure.jsp
@@ -49,7 +49,7 @@ renderResponse.setTitle(title);
 
 <portlet:actionURL name="/document_library/ddm/update_ddm_structure" var="updateDDMStructureURL" />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form action="<%= (ddmStructure == null) ? addDDMStructureURL : updateDDMStructureURL %>" method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + renderResponse.getNamespace() + "saveDDMStructure();" %>'>
 		<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
 		<aui:input name="ddmStructureId" type="hidden" value="<%= ddmStructureId %>" />
@@ -208,7 +208,7 @@ renderResponse.setTitle(title);
 
 		<aui:button href="<%= redirect %>" type="cancel" />
 	</aui:button-row>
-</div>
+</clay:container>
 
 <aui:script>
 	function <portlet:namespace />openParentDDMStructureSelector() {

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
@@ -137,7 +137,7 @@ renderResponse.setTitle(headerTitle);
 	</liferay-frontend:info-bar>
 </c:if>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<c:if test="<%= checkedOut %>">
 
 		<%
@@ -555,7 +555,7 @@ renderResponse.setTitle(headerTitle);
 		id="<%= uploadProgressId %>"
 		message="uploading"
 	/>
-</div>
+</clay:container>
 
 <c:if test="<%= (fileEntry != null) && checkedOut && dlAdminDisplayContext.isVersioningStrategyOverridable() %>">
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry_type_data_layout_builder.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry_type_data_layout_builder.jsp
@@ -64,7 +64,7 @@ renderResponse.setTitle((fileEntryType == null) ? LanguageUtil.get(request, "new
 	<aui:model-context bean="<%= fileEntryType %>" model="<%= DLFileEntryType.class %>" />
 
 	<nav class="component-tbar subnav-tbar-light tbar tbar-metadata-type">
-		<div class="container-fluid container-fluid-max-xl">
+		<clay:container>
 			<ul class="tbar-nav">
 				<li class="tbar-item tbar-item-expand"></li>
 				<li class="tbar-item">
@@ -75,10 +75,12 @@ renderResponse.setTitle((fileEntryType == null) ? LanguageUtil.get(request, "new
 					</div>
 				</li>
 			</ul>
-		</div>
+		</clay:container>
 	</nav>
 
-	<div class="container-fluid container-fluid-max-xl container-view">
+	<clay:container
+		className="container-view"
+	>
 
 		<%
 		DLEditFileEntryTypeDisplayContext dlEditFileEntryTypeDisplayContext = (DLEditFileEntryTypeDisplayContext)request.getAttribute(DLWebKeys.DOCUMENT_LIBRARY_EDIT_EDIT_FILE_ENTRY_TYPE_DISPLAY_CONTEXT);
@@ -94,7 +96,7 @@ renderResponse.setTitle((fileEntryType == null) ? LanguageUtil.get(request, "new
 			localizable="<%= true %>"
 			namespace="<%= renderResponse.getNamespace() %>"
 		/>
-	</div>
+	</clay:container>
 </aui:form>
 
 <aui:script>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry_type_form_builder.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry_type_form_builder.jsp
@@ -33,7 +33,7 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle((fileEntryType == null) ? LanguageUtil.get(request, "new-document-type") : fileEntryType.getName(locale));
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<portlet:actionURL name="/document_library/edit_file_entry_type" var="editFileEntryTypeURL">
 		<portlet:param name="mvcRenderCommandName" value="/document_library/edit_file_entry_type" />
 	</portlet:actionURL>
@@ -81,7 +81,7 @@ renderResponse.setTitle((fileEntryType == null) ? LanguageUtil.get(request, "new
 			<aui:button href="<%= redirect %>" type="cancel" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	function <portlet:namespace />saveStructure() {

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_shortcut.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_shortcut.jsp
@@ -24,7 +24,7 @@ DLEditFileShortcutDisplayContext dlEditFileShortcutDisplayContext = (DLEditFileS
 renderResponse.setTitle(dlEditFileShortcutDisplayContext.getTitle());
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form action="<%= dlEditFileShortcutDisplayContext.getEditFileShortcutURL() %>" method="post" name="fm">
 		<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
 		<aui:input name="fileShortcutId" type="hidden" value="<%= dlEditFileShortcutDisplayContext.getFileShortcutId() %>" />
@@ -63,7 +63,7 @@ renderResponse.setTitle(dlEditFileShortcutDisplayContext.getTitle());
 			<aui:button href="<%= redirect %>" type="cancel" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script require="frontend-js-web/liferay/ItemSelectorDialog.es as ItemSelectorDialog">
 	var selectToFileEntryButton = document.getElementById(

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_folder.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_folder.jsp
@@ -63,7 +63,7 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(headerTitle);
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-util:buffer
 		var="removeFileEntryTypeIcon"
 	>
@@ -307,7 +307,7 @@ renderResponse.setTitle(headerTitle);
 			<aui:button href="<%= redirect %>" type="cancel" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:container>
 
 <liferay-util:buffer
 	var="workflowDefinitionsBuffer"

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_repository.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_repository.jsp
@@ -33,7 +33,7 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(headerTitle);
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<portlet:actionURL name="/document_library/edit_repository" var="editRepositoryURL">
 		<portlet:param name="mvcRenderCommandName" value="/document_library/edit_repository" />
 	</portlet:actionURL>
@@ -169,7 +169,7 @@ renderResponse.setTitle(headerTitle);
 		%>
 
 	</div>
-</div>
+</clay:container>
 
 <aui:script require="metal-dom/src/dom as dom">
 	var settingsParametersContainer = document.getElementById(

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_upper_tbar.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_upper_tbar.jsp
@@ -25,7 +25,7 @@ FileVersion fileVersion = (FileVersion)request.getAttribute("file_entry_upper_tb
 
 <div class="upper-tbar-container-fixed">
 	<div class="tbar upper-tbar">
-		<div class="container-fluid container-fluid-max-xl">
+		<clay:container>
 			<ul class="tbar-nav">
 				<li class="tbar-item tbar-item-expand">
 					<div class="tbar-section text-left">
@@ -94,6 +94,6 @@ FileVersion fileVersion = (FileVersion)request.getAttribute("file_entry_upper_tb
 					/>
 				</li>
 			</ul>
-		</div>
+		</clay:container>
 	</div>
 </div>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_file_entry.jsp
@@ -45,7 +45,7 @@ List<Object> foldersAndFileEntriesAndFileShortcuts = DLAppServiceUtil.getFolders
 dlSearchContainer.setResults(foldersAndFileEntriesAndFileShortcuts);
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form method="post" name="selectFileEntryFm">
 		<liferay-ui:breadcrumb
 			showGuestGroup="<%= false %>"
@@ -131,7 +131,7 @@ dlSearchContainer.setResults(foldersAndFileEntriesAndFileShortcuts);
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	Liferay.Util.selectEntityHandler(

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_file_version.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_file_version.jsp
@@ -36,7 +36,7 @@ if ((user.getUserId() == fileEntry.getUserId()) || permissionChecker.isContentRe
 	<portlet:param name="version" value="<%= String.valueOf(fileVersion.getVersion()) %>" />
 </liferay-portlet:renderURL>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form action="<%= portletURL.toString() %>" method="post" name="selectFileVersionFm">
 		<liferay-ui:search-container
 			id="fileVersionSearchContainer"
@@ -92,7 +92,7 @@ if ((user.getUserId() == fileEntry.getUserId()) || permissionChecker.isContentRe
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	Liferay.Util.selectEntityHandler(

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_folder.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_folder.jsp
@@ -36,7 +36,7 @@ if (folder != null) {
 DLVisualizationHelper dlVisualizationHelper = new DLVisualizationHelper(dlRequestHelper);
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form method="post" name="selectFolderFm">
 		<liferay-ui:breadcrumb
 			showCurrentGroup="<%= false %>"
@@ -176,7 +176,7 @@ DLVisualizationHelper dlVisualizationHelper = new DLVisualizationHelper(dlReques
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	Liferay.Util.selectEntityHandler(

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_group.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_group.jsp
@@ -24,7 +24,7 @@ PortletURL portletURL = renderResponse.createRenderURL();
 portletURL.setParameter("mvcPath", "/document_library/select_group.jsp");
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<clay:management-toolbar
 		clearResultsURL="<%= portletURL.toString() %>"
 		searchActionURL="<%= portletURL.toString() %>"
@@ -141,7 +141,7 @@ portletURL.setParameter("mvcPath", "/document_library/select_group.jsp");
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	Liferay.Util.selectEntityHandler(

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
@@ -99,10 +99,15 @@ if (portletTitleBasedNavigation) {
 
 <c:choose>
 	<c:when test="<%= portletTitleBasedNavigation %>">
-<div class="container-fluid-1280" id="<portlet:namespace />FileEntry">
+		<clay:container
+			id='<%= renderResponse.getNamespace() + "FileEntry" %>'
+		>
 	</c:when>
 	<c:otherwise>
-<div class="closed container-fluid-1280 sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
+		<clay:container
+			className="closed sidenav-container sidenav-right"
+			id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
+		>
 	</c:otherwise>
 </c:choose>
 
@@ -231,7 +236,7 @@ if (portletTitleBasedNavigation) {
 			</c:if>
 		</div>
 	</div>
-</div>
+</clay:container>
 
 <c:if test="<%= dlPortletInstanceSettingsHelper.isShowActions() && dlAdminDisplayContext.isVersioningStrategyOverridable() %>">
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_metadata_sets.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_metadata_sets.jsp
@@ -26,7 +26,9 @@ DLViewFileEntryMetadataSetsDisplayContext dLViewFileEntryMetadataSetsDisplayCont
 	displayContext="<%= new DLViewFileEntryMetadataSetsManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, dLViewFileEntryMetadataSetsDisplayContext) %>"
 />
 
-<div class="container-fluid container-fluid-max-xl main-content-body">
+<clay:container
+	className="main-content-body"
+>
 	<liferay-ui:error exception="<%= RequiredStructureException.MustNotDeleteStructureReferencedByStructureLinks.class %>" message="the-structure-cannot-be-deleted-because-it-is-required-by-one-or-more-structure-links" />
 	<liferay-ui:error exception="<%= RequiredStructureException.MustNotDeleteStructureReferencedByTemplates.class %>" message="the-structure-cannot-be-deleted-because-it-is-required-by-one-or-more-templates" />
 	<liferay-ui:error exception="<%= RequiredStructureException.MustNotDeleteStructureThatHasChild.class %>" message="the-structure-cannot-be-deleted-because-it-has-one-or-more-substructures" />
@@ -106,4 +108,4 @@ DLViewFileEntryMetadataSetsDisplayContext dLViewFileEntryMetadataSetsDisplayCont
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_types.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_types.jsp
@@ -32,7 +32,9 @@ DLViewFileEntryTypesDisplayContext dlViewFileEntryTypesDisplayContext = new DLVi
 	selectable="<%= false %>"
 />
 
-<div class="container-fluid container-fluid-max-xl main-content-body">
+<clay:container
+	className="main-content-body"
+>
 	<liferay-ui:error exception="<%= RequiredFileEntryTypeException.class %>" message="cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents" />
 
 	<liferay-ui:search-container
@@ -86,4 +88,4 @@ DLViewFileEntryTypesDisplayContext dlViewFileEntryTypesDisplayContext = new DLVi
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-taglib/src/main/resources/META-INF/resources/ddm_form_renderer/init.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-taglib/src/main/resources/META-INF/resources/ddm_form_renderer/init.jsp
@@ -30,3 +30,5 @@ Map<String, Object> dynamicAttributes = (Map<String, Object>)request.getAttribut
 %>
 
 <%@ include file="/ddm_form_renderer/init-ext.jspf" %>
+
+<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-taglib/src/main/resources/META-INF/resources/ddm_form_renderer/page.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-taglib/src/main/resources/META-INF/resources/ddm_form_renderer/page.jsp
@@ -85,7 +85,7 @@ if (ddmFormInstance != null) {
 
 					<c:if test="<%= showFormBasicInfo %>">
 						<div class="ddm-form-basic-info">
-							<div class="container-fluid-1280">
+							<clay:container>
 								<h1 class="ddm-form-name"><%= HtmlUtil.escape(ddmFormInstance.getName(displayLocale)) %></h1>
 
 								<%
@@ -95,15 +95,17 @@ if (ddmFormInstance != null) {
 								<c:if test="<%= Validator.isNotNull(description) %>">
 									<h5 class="ddm-form-description"><%= description %></h5>
 								</c:if>
-							</div>
+							</clay:container>
 						</div>
 					</c:if>
 
-					<div class="container-fluid-1280 ddm-form-builder-app">
+					<clay:container
+						className="ddm-form-builder-app"
+					>
 						<%= ddmFormHTML %>
 
 						<aui:input name="empty" type="hidden" value="" />
-					</div>
+					<clay:container>
 				</div>
 			</c:when>
 			<c:when test="<%= !hasViewFormInstancePermission %>">

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_element_set.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_element_set.jsp
@@ -47,7 +47,9 @@ renderResponse.setTitle((structure == null) ? LanguageUtil.get(request, "new-ele
 	/>
 
 	<nav class="management-bar management-bar-light navbar navbar-expand-md toolbar-group-field">
-		<div class="container toolbar">
+		<clay:container
+			className="toolbar"
+		>
 			<ul class="navbar-nav toolbar-group-field"></ul>
 			<ul class="navbar-nav toolbar-group-field">
 				<li class="nav-item">
@@ -58,17 +60,19 @@ renderResponse.setTitle((structure == null) ? LanguageUtil.get(request, "new-ele
 					</button>
 				</li>
 			</ul>
-		</div>
+		</clay:container>
 	</nav>
 
-	<div class="container-fluid-1280 ddm-translation-manager">
+	<clay:container
+		className="ddm-translation-manager"
+	>
 		<liferay-frontend:translation-manager
 			availableLocales="<%= ddmFormAdminDisplayContext.getAvailableLocales() %>"
 			changeableDefaultLanguage="<%= false %>"
 			defaultLanguageId="<%= ddmFormAdminDisplayContext.getDefaultLanguageId() %>"
 			id="translationManager"
 		/>
-	</div>
+	</clay:container>
 
 	<aui:form action="<%= saveStructureURL %>" cssClass="ddm-form-builder-form" method="post" name="editForm">
 		<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
@@ -81,7 +85,7 @@ renderResponse.setTitle((structure == null) ? LanguageUtil.get(request, "new-ele
 		<%@ include file="/admin/exceptions.jspf" %>
 
 		<div class="ddm-form-basic-info">
-			<div class="container-fluid-1280">
+			<clay:container>
 				<h1>
 					<liferay-editor:editor
 						autoCreate="<%= false %>"
@@ -109,7 +113,7 @@ renderResponse.setTitle((structure == null) ? LanguageUtil.get(request, "new-ele
 				</h5>
 
 				<aui:input name="description" type="hidden" />
-			</div>
+			</clay:container>
 		</div>
 
 		<div id="<portlet:namespace />-container"></div>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
@@ -42,7 +42,7 @@ renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-
 </portlet:actionURL>
 
 <div class="lfr-alert-container">
-	<div class="container-fluid-1280 lfr-alert-wrapper"></div>
+	<clay:container className="lfr-alert-wrapper"></clay:container>
 </div>
 
 <div class="portlet-forms" id="<portlet:namespace />formContainer">
@@ -54,7 +54,9 @@ renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-
 	/>
 
 	<nav class="management-bar management-bar-light navbar navbar-expand-md toolbar-group-field" id="<portlet:namespace />managementToolbar">
-		<div class="autosave-bar container toolbar">
+		<clay:container
+			className="autosave-bar toolbar"
+		>
 			<div class="navbar-form navbar-form-autofit navbar-overlay toolbar-group-content">
 				<span class="autosave-feedback management-bar-text" id="<portlet:namespace />autosaveMessage"></span>
 			</div>
@@ -75,17 +77,19 @@ renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-
 					</button>
 				</li>
 			</ul>
-		</div>
+		</clay:container>
 	</nav>
 
-	<div class="container-fluid-1280 ddm-translation-manager">
+	<clay:container
+		className="ddm-translation-manager"
+	>
 		<liferay-frontend:translation-manager
 			availableLocales="<%= ddmFormAdminDisplayContext.getAvailableLocales() %>"
 			changeableDefaultLanguage="<%= false %>"
 			defaultLanguageId="<%= ddmFormAdminDisplayContext.getDefaultLanguageId() %>"
 			id="translationManager"
 		/>
-	</div>
+	</clay:container>
 
 	<aui:form action="<%= saveFormInstanceURL %>" cssClass="ddm-form-builder-form" enctype="multipart/form-data" method="post" name="editForm">
 		<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
@@ -100,7 +104,7 @@ renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-
 		<%@ include file="/admin/exceptions.jspf" %>
 
 		<div class="ddm-form-basic-info">
-			<div class="container-fluid-1280">
+			<clay:container>
 				<h1>
 					<liferay-editor:editor
 						autoCreate="<%= false %>"
@@ -124,15 +128,18 @@ renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-
 						showSource="<%= false %>"
 					/>
 				</h5>
-			</div>
+			</clay:container>
 		</div>
 
 		<div id="<portlet:namespace />-container"></div>
 	</aui:form>
 
-	<div class="container-fluid-1280 ddm-form-instance-settings hide" id="<portlet:namespace />settings">
+	<clay:container
+		className="ddm-form-instance-settings hide"
+		id="<portlet:namespace />settings"
+	>
 		<%= ddmFormAdminDisplayContext.serializeSettingsForm(pageContext) %>
-	</div>
+	</clay:container>
 </div>
 
 <portlet:actionURL name="publishFormInstance" var="publishFormInstanceURL">

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance_record.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance_record.jsp
@@ -31,15 +31,17 @@ renderResponse.setTitle(GetterUtil.get(title, LanguageUtil.get(request, "view-fo
 
 <div class="portlet-forms">
 	<div class="ddm-form-basic-info ddm-form-success-page">
-		<div class="container-fluid-1280">
+		<clay:container>
 			<h1 class="ddm-form-name"><%= ddmFormAdminDisplayContext.getFormName() %></h1>
 
 			<h5 class="ddm-form-description"><%= ddmFormAdminDisplayContext.getFormDescription() %></h5>
-		</div>
+		</clay:container>
 	</div>
 </div>
 
-<div class="container-fluid-1280 ddm-form-builder-app editing-form-entry">
+<clay:container
+	className="ddm-form-builder-app editing-form-entry"
+>
 	<portlet:actionURL name="addFormInstanceRecord" var="editFormInstanceRecordActionURL" />
 
 	<aui:form action="<%= editFormInstanceRecordActionURL %>" data-DDMFormInstanceId="<%= ddmFormInstanceRecordVersion.getFormInstanceId() %>" data-senna-off="true" method="post" name="fm">
@@ -49,4 +51,4 @@ renderResponse.setTitle(GetterUtil.get(title, LanguageUtil.get(request, "view-fo
 
 		<%= ddmFormAdminDisplayContext.getDDMFormHTML(renderRequest) %>
 	</aui:form>
-</div>
+</clay:container>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/form_instance_records_search_container.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/form_instance_records_search_container.jsp
@@ -37,7 +37,9 @@ PortletURL portletURL = ddmFormViewFormInstanceRecordsDisplayContext.getPortletU
 	sortingURL="<%= ddmFormViewFormInstanceRecordsDisplayContext.getSortingURL() %>"
 />
 
-<div class="container-fluid-1280" id="<portlet:namespace />viewEntriesContainer">
+<clay:container
+	id='<%= renderResponse.getNamespace() + "viewEntriesContainer" %>'
+>
 	<aui:form action="<%= portletURL.toString() %>" method="post" name="searchContainerForm">
 		<aui:input name="deleteFormInstanceRecordIds" type="hidden" />
 
@@ -113,13 +115,13 @@ PortletURL portletURL = ddmFormViewFormInstanceRecordsDisplayContext.getPortletU
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-ui:search-paginator
 		searchContainer="<%= ddmFormViewFormInstanceRecordsDisplayContext.getSearch() %>"
 	/>
-</div>
+</clay:container>
 
 <%@ include file="/admin/export_form_instance.jspf" %>
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/view_element_set.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/view_element_set.jsp
@@ -26,7 +26,9 @@ portletURL.setParameter("displayStyle", displayStyle);
 FieldSetPermissionCheckerHelper fieldSetPermissionCheckerHelper = ddmFormAdminDisplayContext.getPermissionCheckerHelper();
 %>
 
-<div class="container-fluid-1280" id="<portlet:namespace />formContainer">
+<clay:container
+	id='<%= renderResponse.getNamespace() + "formContainer" %>'
+>
 	<aui:form action="<%= portletURL.toString() %>" method="post" name="searchContainerForm">
 		<aui:input name="redirect" type="hidden" value="<%= portletURL.toString() %>" />
 		<aui:input name="deleteStructureIds" type="hidden" />
@@ -104,6 +106,6 @@ FieldSetPermissionCheckerHelper fieldSetPermissionCheckerHelper = ddmFormAdminDi
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script use="liferay-ddm-form-portlet"></aui:script>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/view_form_instance.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/view_form_instance.jsp
@@ -23,7 +23,9 @@ PortletURL portletURL = ddmFormAdminDisplayContext.getPortletURL();
 FormInstancePermissionCheckerHelper formInstancePermissionCheckerHelper = ddmFormAdminDisplayContext.getPermissionCheckerHelper();
 %>
 
-<div class="container-fluid-1280" id="<portlet:namespace />formContainer">
+<clay:container
+	id='<%= renderResponse.getNamespace() + "formContainer" %>'
+>
 	<aui:form action="<%= portletURL.toString() %>" method="post" name="searchContainerForm">
 		<aui:input name="redirect" type="hidden" value="<%= portletURL.toString() %>" />
 		<aui:input name="deleteFormInstanceIds" type="hidden" />
@@ -102,7 +104,7 @@ FormInstancePermissionCheckerHelper formInstancePermissionCheckerHelper = ddmFor
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script require='<%= mainRequire + "/admin/js/components/ShareFormPopover/ShareFormPopover.es as ShareFormPopover" %>'>
 	var spritemap = themeDisplay.getPathThemeImages() + '/lexicon/icons.svg';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/view_form_instance_record.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/view_form_instance_record.jsp
@@ -27,7 +27,7 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(LanguageUtil.get(request, "view-form"));
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<c:if test="<%= formInstanceRecordVersion != null %>">
 		<aui:model-context bean="<%= formInstanceRecordVersion %>" model="<%= DDMFormInstanceRecordVersion.class %>" />
 
@@ -35,8 +35,10 @@ renderResponse.setTitle(LanguageUtil.get(request, "view-form"));
 			<aui:workflow-status markupView="lexicon" model="<%= DDMFormInstanceRecord.class %>" showHelpMessage="<%= false %>" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= formInstanceRecordVersion.getStatus() %>" version="<%= formInstanceRecordVersion.getVersion() %>" />
 		</div>
 	</c:if>
-</div>
+</clay:container>
 
-<div class="container-fluid-1280 ddm-form-builder-app form-entry">
+<clay:container
+	className="ddm-form-builder-app form-entry"
+>
 	<%= ddmFormAdminDisplayContext.getDDMFormHTML(renderRequest) %>
-</div>
+</clay:container>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/asset/full_content.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/asset/full_content.jsp
@@ -20,6 +20,6 @@
 DDMFormViewFormInstanceRecordDisplayContext ddmFormViewFormInstanceRecordDisplayContext = (DDMFormViewFormInstanceRecordDisplayContext)request.getAttribute(WebKeys.PORTLET_DISPLAY_CONTEXT);
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<%= ddmFormViewFormInstanceRecordDisplayContext.getDDMFormHTML(renderRequest) %>
-</div>
+</clay:container>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/asset/init.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/asset/init.jsp
@@ -16,7 +16,8 @@
 
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
-<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %>
+<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui"
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %>
 
 <%@ page import="com.liferay.dynamic.data.mapping.form.web.internal.display.context.DDMFormViewFormInstanceRecordDisplayContext" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/browser/view.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/browser/view.jsp
@@ -34,7 +34,9 @@
 	sortingURL="<%= ddmFormBrowserDisplayContext.getSortingURL() %>"
 />
 
-<div class="container-fluid-1280" id="<portlet:namespace />formContainer">
+<clay:container
+	id='<%= renderResponse.getNamespace() + "formContainer" %>'
+>
 	<aui:form action="<%= String.valueOf(ddmFormBrowserDisplayContext.getPortletURL()) %>" method="post" name="selectDDMFormFm">
 		<liferay-ui:search-container
 			id="<%= ddmFormBrowserDisplayContext.getSearchContainerId() %>"
@@ -85,7 +87,7 @@
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	Liferay.Util.selectEntityHandler(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/configuration.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/configuration.jsp
@@ -40,7 +40,7 @@ DDMFormInstance selFormInstance = DDMFormInstanceServiceUtil.fetchFormInstance(f
 	<aui:input name="redirect" type="hidden" value="<%= configurationRenderURL.toString() %>" />
 
 	<div class="portlet-configuration-body-content">
-		<div class="container-fluid-1280">
+		<clay:container>
 			<div class="alert alert-info">
 				<span class="displaying-help-message-holder <%= (selFormInstance == null) ? StringPool.BLANK : "hide" %>">
 					<liferay-ui:message key="please-select-a-form-from-the-list-below" />
@@ -126,7 +126,7 @@ DDMFormInstance selFormInstance = DDMFormInstanceServiceUtil.fetchFormInstance(f
 					</div>
 				</div>
 			</aui:fieldset>
-		</div>
+		</clay:container>
 	</div>
 </aui:form>
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/view.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/view.jsp
@@ -30,24 +30,24 @@ long formInstanceId = ddmFormDisplayContext.getFormInstanceId();
 	</c:when>
 	<c:when test="<%= !ddmFormDisplayContext.hasAddFormInstanceRecordPermission() && !ddmFormDisplayContext.hasViewPermission() %>">
 		<div class="ddm-form-basic-info">
-			<div class="container-fluid-1280">
+			<clay:container>
 				<clay:alert
 					message='<%= LanguageUtil.get(resourceBundle, "you-do-not-have-the-permission-to-view-this-form") %>'
 					style="warning"
 					title='<%= LanguageUtil.get(resourceBundle, "warning") %>'
 				/>
-			</div>
+			</clay:container>
 		</div>
 	</c:when>
 	<c:when test="<%= ddmFormDisplayContext.isRequireAuthentication() %>">
 		<div class="ddm-form-basic-info">
-			<div class="container-fluid-1280">
+			<clay:container>
 				<clay:alert
 					message='<%= LanguageUtil.get(resourceBundle, "you-need-to-be-signed-in-to-view-this-form") %>'
 					style="warning"
 					title='<%= LanguageUtil.get(resourceBundle, "warning") %>'
 				/>
-			</div>
+			</clay:container>
 		</div>
 	</c:when>
 	<c:otherwise>
@@ -70,11 +70,11 @@ long formInstanceId = ddmFormDisplayContext.getFormInstanceId();
 
 				<div class="portlet-forms">
 					<div class="ddm-form-basic-info ddm-form-success-page">
-						<div class="container-fluid-1280">
+						<clay:container>
 							<h1 class="ddm-form-name"><%= HtmlUtil.escape(GetterUtil.getString(title.getString(displayLocale), title.getString(title.getDefaultLocale()))) %></h1>
 
 							<h5 class="ddm-form-description"><%= HtmlUtil.escape(GetterUtil.getString(body.getString(displayLocale), body.getString(body.getDefaultLocale()))) %></h5>
-						</div>
+						</clay:container>
 					</div>
 				</div>
 			</c:when>
@@ -133,7 +133,7 @@ long formInstanceId = ddmFormDisplayContext.getFormInstanceId();
 						<liferay-ui:error-principal />
 
 						<c:if test="<%= ddmFormDisplayContext.isFormShared() %>">
-							<div class="container-fluid-1280">
+							<clay:container>
 								<div class="locale-actions">
 									<liferay-ui:language
 										formAction="<%= currentURL %>"
@@ -141,23 +141,23 @@ long formInstanceId = ddmFormDisplayContext.getFormInstanceId();
 										languageIds="<%= ddmFormDisplayContext.getAvailableLanguageIds() %>"
 									/>
 								</div>
-							</div>
+							</clay:container>
 						</c:if>
 
 						<c:if test="<%= !ddmFormDisplayContext.hasAddFormInstanceRecordPermission() %>">
 							<div class="ddm-form-basic-info">
-								<div class="container-fluid-1280">
+								<clay:container>
 									<clay:alert
 										message='<%= LanguageUtil.get(resourceBundle, "you-do-not-have-the-permission-to-submit-this-form") %>'
 										style="warning"
 										title='<%= LanguageUtil.get(resourceBundle, "warning") %>'
 									/>
-								</div>
+								</clay:container>
 							</div>
 						</c:if>
 
 						<div class="ddm-form-basic-info">
-							<div class="container-fluid-1280">
+							<clay:container>
 								<h1 class="ddm-form-name"><%= HtmlUtil.escape(formInstance.getName(displayLocale)) %></h1>
 
 								<%
@@ -167,14 +167,17 @@ long formInstanceId = ddmFormDisplayContext.getFormInstanceId();
 								<c:if test="<%= Validator.isNotNull(description) %>">
 									<h5 class="ddm-form-description"><%= description %></h5>
 								</c:if>
-							</div>
+							</clay:container>
 						</div>
 
-						<div class="container-fluid-1280 ddm-form-builder-app ddm-form-builder-app-not-ready" id="<%= ddmFormDisplayContext.getContainerId() %>container">
+						<clay:container
+							className="ddm-form-builder-app ddm-form-builder-app-not-ready"
+							id="<%= ddmFormDisplayContext.getContainerId() %>container"
+						>
 							<%= ddmFormDisplayContext.getDDMFormHTML() %>
 
 							<aui:input name="empty" type="hidden" value="" />
-						</div>
+						</clay:container>
 					</aui:form>
 				</div>
 

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view.jsp
@@ -24,7 +24,9 @@ List<FragmentCollection> systemFragmentCollections = (List<FragmentCollection>)r
 List<FragmentCollectionContributor> fragmentCollectionContributors = fragmentDisplayContext.getFragmentCollectionContributors(locale);
 %>
 
-<div class="container-fluid container-fluid-max-xl container-view">
+<clay:container
+	className="container-view"
+>
 	<clay:row>
 		<clay:col
 			lg="3"
@@ -272,7 +274,7 @@ List<FragmentCollectionContributor> fragmentCollectionContributors = fragmentDis
 			</c:if>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>
 
 <aui:form cssClass="hide" name="fragmentCollectionsFm">
 </aui:form>

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_fragment_entry_usages.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_fragment_entry_usages.jsp
@@ -27,7 +27,9 @@ portletDisplay.setURLBack(fragmentEntryLinkDisplayContext.getRedirect());
 renderResponse.setTitle(LanguageUtil.format(request, "usages-and-propagation-x", fragmentEntry.getName()));
 %>
 
-<div class="container-fluid container-fluid-max-xl container-form-lg">
+<clay:container
+	className="container-form-lg"
+>
 
 	<%
 	FragmentEntryUsageManagementToolbarDisplayContext fragmentEntryUsageManagementToolbarDisplayContext = new FragmentEntryUsageManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, fragmentEntryLinkDisplayContext.getSearchContainer());
@@ -176,7 +178,7 @@ renderResponse.setTitle(LanguageUtil.format(request, "usages-and-propagation-x",
 			</div>
 		</clay:col>
 	</clay:row>
-</div>
+</clay:container>
 
 <liferay-frontend:component
 	componentId="<%= fragmentEntryUsageManagementToolbarDisplayContext.getDefaultEventHandler() %>"

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_group_fragment_entry_usages.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_group_fragment_entry_usages.jsp
@@ -27,7 +27,9 @@ portletDisplay.setURLBack(groupFragmentEntryLinkDisplayContext.getRedirect());
 renderResponse.setTitle(LanguageUtil.format(request, "usages-and-propagation-x", fragmentEntry.getName()));
 %>
 
-<div class="container-fluid container-fluid-max-xl container-form-lg">
+<clay:container
+	className="container-form-lg"
+>
 	<div class="sheet">
 
 		<%
@@ -79,7 +81,7 @@ renderResponse.setTitle(LanguageUtil.format(request, "usages-and-propagation-x",
 			</clay:col>
 		</clay:row>
 	</div>
-</div>
+</clay:container>
 
 <liferay-frontend:component
 	componentId="<%= groupFragmentEntryUsageManagementToolbarDisplayContext.getDefaultEventHandler() %>"

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/group_selector/page.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/group_selector/page.jsp
@@ -23,7 +23,7 @@ Set<String> groupTypes = groupSelectorDisplayContext.getGroupTypes();
 %>
 
 <c:if test="<%= groupTypes.size() > 1 %>">
-	<div class="container-fluid-1280">
+	<clay:container>
 		<div class="btn-group btn-group-sm my-3" role="group">
 
 			<%
@@ -37,10 +37,12 @@ Set<String> groupTypes = groupSelectorDisplayContext.getGroupTypes();
 			%>
 
 		</div>
-	</div>
+	</clay:container>
 </c:if>
 
-<div class="container-fluid-1280 lfr-item-viewer">
+<clay:container
+	className="lfr-item-viewer"
+>
 	<liferay-ui:search-container
 		searchContainer="<%= groupSelectorDisplayContext.getSearchContainer() %>"
 		var="listSearchContainer"
@@ -82,4 +84,4 @@ Set<String> groupTypes = groupSelectorDisplayContext.getGroupTypes();
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/init.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/init.jsp
@@ -16,7 +16,5 @@
 
 <%@ include file="/init.jsp" %>
 
-<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %>
-
 <%@ page import="com.liferay.document.library.util.DLURLHelperUtil" %><%@
 page import="com.liferay.portal.kernel.servlet.BrowserSnifferUtil" %>

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/init.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/document-library" prefix="liferay-document-library" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/init.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/init.jsp
@@ -16,8 +16,6 @@
 
 <%@ include file="/init.jsp" %>
 
-<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %>
-
 <%@ page import="com.liferay.document.library.util.DLURLHelperUtil" %><%@
 page import="com.liferay.item.selector.ItemSelectorReturnType" %><%@
 page import="com.liferay.item.selector.taglib.internal.display.context.ItemSelectorRepositoryEntryManagementToolbarDisplayContext" %><%@

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
@@ -70,7 +70,10 @@ ItemSelectorRepositoryEntryManagementToolbarDisplayContext itemSelectorRepositor
 	viewTypeItems="<%= itemSelectorRepositoryEntryManagementToolbarDisplayContext.getViewTypes() %>"
 />
 
-<div class="container-fluid container-fluid-max-xl item-selector lfr-item-viewer" id="<%= randomNamespace %>ItemSelectorContainer">
+<clay:container
+	className="item-selector lfr-item-viewer"
+	id="<%= randomNamespace %>ItemSelectorContainer"
+>
 	<c:if test="<%= showSearchInfo %>">
 		<liferay-util:include page="/repository_entry_browser/search_info.jsp" servletContext="<%= application %>" />
 	</c:if>
@@ -508,7 +511,7 @@ ItemSelectorRepositoryEntryManagementToolbarDisplayContext itemSelectorRepositor
 	</c:if>
 
 	<div class="item-selector-preview-container"></div>
-</div>
+</clay:container>
 
 <aui:script require='<%= npmResolvedPackageName + "/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es as ItemSelectorRepositoryEntryBrowser" %>'>
 	var itemSelector = new ItemSelectorRepositoryEntryBrowser.default({

--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view_item_selector_view_descriptor.jsp
@@ -30,7 +30,10 @@ SearchContainer searchContainer = itemSelectorViewDescriptor.getSearchContainer(
 	/>
 </c:if>
 
-<div class="container-fluid container-fluid-max-xl item-selector lfr-item-viewer" id="<portlet:namespace />entriesContainer">
+<clay:container
+	className="item-selector lfr-item-viewer"
+	id='<%= renderResponse.getNamespace() + "entriesContainer" %>'
+>
 	<c:if test="<%= itemSelectorViewDescriptor.isShowBreadcrumb() %>">
 		<liferay-site-navigation:breadcrumb
 			breadcrumbEntries="<%= itemSelectorViewDescriptorRendererDisplayContext.getBreadcrumbEntries(currentURLObj) %>"
@@ -136,7 +139,7 @@ SearchContainer searchContainer = itemSelectorViewDescriptor.getSearchContainer(
 			searchContainer="<%= searchContainer %>"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>
 
 <aui:script require="metal-dom/src/all/dom as dom">
 	var selectItemHandler = dom.delegate(

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/compare_versions.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/compare_versions.jsp
@@ -47,7 +47,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "compare-versions"));
 	<portlet:param name="articleId" value="<%= articleId %>" />
 </liferay-portlet:resourceURL>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-frontend:diff-version-comparator
 		availableLocales="<%= availableLocales %>"
 		diffHtmlResults="<%= diffHtmlResults %>"
@@ -58,4 +58,4 @@ renderResponse.setTitle(LanguageUtil.get(request, "compare-versions"));
 		sourceVersion="<%= sourceVersion %>"
 		targetVersion="<%= targetVersion %>"
 	/>
-</div>
+</clay:container>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -53,7 +53,7 @@ JournalEditArticleDisplayContext journalEditArticleDisplayContext = new JournalE
 	<aui:input name="workflowAction" type="hidden" value="<%= String.valueOf(WorkflowConstants.ACTION_SAVE_DRAFT) %>" />
 
 	<nav class="component-tbar subnav-tbar-light tbar tbar-article">
-		<div class="container-fluid container-fluid-max-xl">
+		<clay:container>
 			<ul class="tbar-nav">
 				<li class="tbar-item tbar-item-expand">
 
@@ -97,7 +97,7 @@ JournalEditArticleDisplayContext journalEditArticleDisplayContext = new JournalE
 					</div>
 				</li>
 			</ul>
-		</div>
+		</clay:container>
 	</nav>
 
 	<div class="contextual-sidebar edit-article-sidebar sidebar-light sidebar-sm" id="<portlet:namespace />contextualSidebarContainer">
@@ -138,7 +138,9 @@ JournalEditArticleDisplayContext journalEditArticleDisplayContext = new JournalE
 	</div>
 
 	<div class="contextual-sidebar-content">
-		<div class="container-fluid container-fluid-max-xl container-view">
+		<clay:container
+			className="container-view"
+		>
 			<div class="sheet sheet-lg">
 				<aui:model-context bean="<%= article %>" defaultLanguageId="<%= journalEditArticleDisplayContext.getDefaultArticleLanguageId() %>" model="<%= JournalArticle.class %>" />
 
@@ -275,7 +277,7 @@ JournalEditArticleDisplayContext journalEditArticleDisplayContext = new JournalE
 					</c:choose>
 				</div>
 			</div>
-		</div>
+		</clay:container>
 	</div>
 </aui:form>
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_structure_data_layout_builder.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_structure_data_layout_builder.jsp
@@ -60,7 +60,7 @@ editDDMStructureURL.setParameter("mvcPath", "/edit_ddm_structure.jsp");
 	<aui:model-context bean="<%= ddmStructure %>" model="<%= DDMStructure.class %>" />
 
 	<nav class="component-tbar subnav-tbar-light tbar tbar-article">
-		<div class="container-fluid container-fluid-max-xl">
+		<clay:container>
 			<ul class="tbar-nav">
 				<li class="tbar-item tbar-item-expand">
 					<aui:input cssClass="form-control-inline" defaultLanguageId="<%= (ddmForm == null) ? LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()): LocaleUtil.toLanguageId(ddmForm.getDefaultLocale()) %>" label="" name="name" placeholder='<%= LanguageUtil.format(request, "untitled-x", "structure") %>' wrapperCssClass="article-content-title mb-0" />
@@ -73,10 +73,12 @@ editDDMStructureURL.setParameter("mvcPath", "/edit_ddm_structure.jsp");
 					</div>
 				</li>
 			</ul>
-		</div>
+		</clay:container>
 	</nav>
 
-	<div class="container-fluid container-fluid-max-xl container-view">
+	<clay:container
+		className="container-view"
+	>
 		<c:if test="<%= (ddmStructure != null) && (DDMStorageLinkLocalServiceUtil.getStructureStorageLinksCount(journalEditDDMStructuresDisplayContext.getDDMStructureId()) > 0) %>">
 			<div class="alert alert-warning">
 				<liferay-ui:message key="there-are-content-references-to-this-structure.-you-may-lose-data-if-a-field-name-is-renamed-or-removed" />
@@ -105,7 +107,7 @@ editDDMStructureURL.setParameter("mvcPath", "/edit_ddm_structure.jsp");
 			namespace="<%= renderResponse.getNamespace() %>"
 			singlePage="<%= true %>"
 		/>
-	</div>
+	</clay:container>
 </aui:form>
 
 <aui:script>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_structure_form_builder.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_structure_form_builder.jsp
@@ -58,7 +58,7 @@ editDDMStructureURL.setParameter("mvcPath", "/edit_ddm_structure.jsp");
 	<aui:model-context bean="<%= ddmStructure %>" model="<%= DDMStructure.class %>" />
 
 	<nav class="component-tbar subnav-tbar-light tbar tbar-article">
-		<div class="container-fluid container-fluid-max-xl">
+		<clay:container>
 			<ul class="tbar-nav">
 				<li class="tbar-item tbar-item-expand">
 					<aui:input cssClass="form-control-inline" defaultLanguageId="<%= (ddmForm == null) ? LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()): LocaleUtil.toLanguageId(ddmForm.getDefaultLocale()) %>" label="" name="name" placeholder='<%= LanguageUtil.format(request, "untitled-x", "structure") %>' wrapperCssClass="article-content-title mb-0" />
@@ -79,7 +79,7 @@ editDDMStructureURL.setParameter("mvcPath", "/edit_ddm_structure.jsp");
 					</div>
 				</li>
 			</ul>
-		</div>
+		</clay:container>
 	</nav>
 
 	<div class="contextual-sidebar edit-article-sidebar sidebar-light sidebar-sm" id="<portlet:namespace />contextualSidebarContainer">
@@ -100,7 +100,9 @@ editDDMStructureURL.setParameter("mvcPath", "/edit_ddm_structure.jsp");
 	</div>
 
 	<div class="contextual-sidebar-content">
-		<div class="container-fluid container-fluid-max-xl container-view">
+		<clay:container
+			className="container-view"
+		>
 			<liferay-ui:error exception="<%= DDMFormLayoutValidationException.class %>" message="please-enter-a-valid-form-layout" />
 
 			<liferay-ui:error exception="<%= DDMFormLayoutValidationException.MustNotDuplicateFieldName.class %>">
@@ -179,7 +181,7 @@ editDDMStructureURL.setParameter("mvcPath", "/edit_ddm_structure.jsp");
 			<div class="sheet">
 				<%@ include file="/ddm_form_builder.jspf" %>
 			</div>
-		</div>
+		</clay:container>
 	</div>
 </aui:form>
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_template.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_template.jsp
@@ -45,7 +45,7 @@ renderResponse.setTitle(journalEditDDMTemplateDisplayContext.getTitle());
 	<aui:model-context bean="<%= ddmTemplate %>" model="<%= DDMTemplate.class %>" />
 
 	<nav class="component-tbar subnav-tbar-light tbar tbar-article">
-		<div class="container-fluid container-fluid-max-xl">
+		<clay:container>
 			<ul class="tbar-nav">
 				<li class="tbar-item tbar-item-expand">
 					<aui:input cssClass="form-control-inline" defaultLanguageId="<%= (ddmTemplate == null) ? LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()): ddmTemplate.getDefaultLanguageId() %>" label="" name="name" placeholder='<%= LanguageUtil.format(request, "untitled-x", "template") %>' wrapperCssClass="article-content-title mb-0" />
@@ -76,7 +76,7 @@ renderResponse.setTitle(journalEditDDMTemplateDisplayContext.getTitle());
 					</div>
 				</li>
 			</ul>
-		</div>
+		</clay:container>
 	</nav>
 
 	<div class="contextual-sidebar edit-article-sidebar sidebar-light sidebar-sm" id="<portlet:namespace />contextualSidebarContainer">
@@ -97,7 +97,9 @@ renderResponse.setTitle(journalEditDDMTemplateDisplayContext.getTitle());
 	</div>
 
 	<div class="contextual-sidebar-content">
-		<div class="container-fluid container-fluid-max-xl container-view">
+		<clay:container
+			className="container-view"
+		>
 			<div class="sheet">
 				<liferay-ui:error exception="<%= TemplateNameException.class %>" message="please-enter-a-valid-name" />
 				<liferay-ui:error exception="<%= TemplateScriptException.class %>" message="please-enter-a-valid-script" />
@@ -110,7 +112,7 @@ renderResponse.setTitle(journalEditDDMTemplateDisplayContext.getTitle());
 
 				<liferay-util:include page="/edit_ddm_template_display.jsp" servletContext="<%= application %>" />
 			</div>
-		</div>
+		</clay:container>
 	</div>
 </aui:form>
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/item/selector/select_articles.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/item/selector/select_articles.jsp
@@ -24,7 +24,10 @@ JournalArticleItemSelectorViewDisplayContext journalArticleItemSelectorViewDispl
 	displayContext="<%= new JournalArticleItemSelectorViewManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, journalArticleItemSelectorViewDisplayContext) %>"
 />
 
-<div class="container-fluid container-fluid-max-xl item-selector lfr-item-viewer" id="<portlet:namespace />articlesContainer">
+<clay:container
+	className="item-selector lfr-item-viewer"
+	id='<%= renderResponse.getNamespace() + "articlesContainer" %>'
+>
 	<liferay-site-navigation:breadcrumb
 		breadcrumbEntries="<%= journalArticleItemSelectorViewDisplayContext.getPortletBreadcrumbEntries() %>"
 	/>
@@ -282,7 +285,7 @@ JournalArticleItemSelectorViewDisplayContext journalArticleItemSelectorViewDispl
 			searchContainer="<%= searchContainer %>"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>
 
 <aui:script require="metal-dom/src/all/dom as dom">
 	var selectArticleHandler = dom.delegate(

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/preview_article_content.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/preview_article_content.jsp
@@ -20,9 +20,11 @@
 JournalArticleDisplay articleDisplay = journalDisplayContext.getArticleDisplay();
 %>
 
-<div class="container-fluid-1280 mt-2">
+<clay:container
+	className="mt-2"
+>
 	<%= articleDisplay.getContent() %>
-</div>
+</clay:container>
 
 <c:if test="<%= articleDisplay.isPaginate() %>">
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view.jsp
@@ -60,7 +60,10 @@ if (Validator.isNotNull(title)) {
 	module="js/ManagementToolbarDefaultEventHandler.es"
 />
 
-<div class="closed container-fluid-1280 sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
+<clay:container
+	className="closed sidenav-container sidenav-right"
+	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
+>
 	<c:if test="<%= journalDisplayContext.isShowInfoButton() %>">
 		<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/journal/info_panel" var="sidebarPanelURL">
 			<portlet:param name="folderId" value="<%= String.valueOf(journalDisplayContext.getFolderId()) %>" />
@@ -143,4 +146,4 @@ if (Validator.isNotNull(title)) {
 			</c:choose>
 		</aui:form>
 	</div>
-</div>
+</clay:container>

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message.jsp
@@ -112,7 +112,9 @@ if (portletTitleBasedNavigation) {
 }
 %>
 
-<div class="container-fluid-1280" id="<%= renderResponse.getNamespace() + "mbEditPageContainer" %>">
+<clay:container
+	id='<%= renderResponse.getNamespace() + "mbEditPageContainer" %>'
+>
 	<c:if test="<%= !portletTitleBasedNavigation %>">
 		<h3><%= headerTitle %></h3>
 	</c:if>
@@ -449,7 +451,7 @@ if (portletTitleBasedNavigation) {
 			<aui:button href="<%= redirect %>" type="cancel" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script require='<%= npmResolvedPackageName + "/message_boards/js/MBPortlet.es as MBPortlet" %>'>
 	new MBPortlet.default({

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/select_category.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/select_category.jsp
@@ -38,7 +38,7 @@ else {
 }
 %>
 
-<div class="container-fluid-1280">
+</clay:container>
 	<aui:form method="post" name="selectCategoryFm">
 		<liferay-ui:breadcrumb
 			showGuestGroup="<%= false %>"
@@ -140,7 +140,7 @@ else {
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+<clay:container>
 
 <aui:script>
 	Liferay.Util.selectEntityHandler(

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_deleted_message_attachments.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_deleted_message_attachments.jsp
@@ -37,7 +37,7 @@ iteratorURL.setParameter("messageId", String.valueOf(messageId));
 String trashEntriesMaxAgeTimeDescription = LanguageUtil.getTimeDescription(locale, trashHelper.getMaxAge(themeDisplay.getScopeGroup()) * Time.MINUTE, true);
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-trash:empty
 		confirmMessage="are-you-sure-you-want-to-remove-the-attachments-for-this-message"
 		emptyMessage="remove-the-attachments-for-this-message"
@@ -103,4 +103,4 @@ String trashEntriesMaxAgeTimeDescription = LanguageUtil.getTimeDescription(local
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view_banned_users.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view_banned_users.jsp
@@ -43,7 +43,7 @@ int totalBannedUsers = MBBanLocalServiceUtil.getBansCount(scopeGroupId);
 	showSearch="<%= false %>"
 />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form action="<%= portletURL.toString() %>" method="get" name="fm">
 		<aui:input name="<%= Constants.CMD %>" type="hidden" />
 		<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
@@ -129,7 +129,7 @@ int totalBannedUsers = MBBanLocalServiceUtil.getBansCount(scopeGroupId);
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <%
 PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, TextFormatter.format("banned-users", TextFormatter.O)), portletURL.toString());

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view_statistics.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view_statistics.jsp
@@ -32,7 +32,7 @@ long categoryId = GetterUtil.getLong(request.getAttribute("view.jsp-categoryId")
 MBCategoryDisplay categoryDisplay = new MBCategoryDisplay(scopeGroupId, categoryId);
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<div class="statistics-panel">
 		<h3><liferay-ui:message key="overview" /></h3>
 
@@ -113,7 +113,7 @@ MBCategoryDisplay categoryDisplay = new MBCategoryDisplay(scopeGroupId, category
 			/>
 		</liferay-ui:search-container>
 	</div>
-</div>
+</clay:container>
 
 <%
 PortalUtil.setPageSubtitle(LanguageUtil.get(request, "statistics"), request);

--- a/modules/apps/organizations/organizations-item-selector-web/build.gradle
+++ b/modules/apps/organizations/organizations-item-selector-web/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:item-selector:item-selector-api")
 	compileOnly project(":apps:item-selector:item-selector-criteria-api")
 	compileOnly project(":apps:item-selector:item-selector-taglib")

--- a/modules/apps/organizations/organizations-item-selector-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/organizations/organizations-item-selector-web/src/main/resources/META-INF/resources/init.jsp
@@ -17,6 +17,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/item-selector" prefix="liferay-item-selector" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@

--- a/modules/apps/organizations/organizations-item-selector-web/src/main/resources/META-INF/resources/organization_item_selector.jsp
+++ b/modules/apps/organizations/organizations-item-selector-web/src/main/resources/META-INF/resources/organization_item_selector.jsp
@@ -55,7 +55,9 @@ PortletURL portletURL = organizationItemSelectorViewDisplayContext.getPortletURL
 	</liferay-frontend:management-bar-filters>
 </liferay-frontend:management-bar>
 
-<div class="container-fluid-1280" id="<portlet:namespace />organizationSelectorWrapper">
+<clay:container
+	id='<%= renderResponse.getNamespace() + "organizationSelectorWrapper" %>'
+>
 	<liferay-ui:search-container
 		id="organizations"
 		searchContainer="<%= organizationItemSelectorViewDisplayContext.getSearchContainer() %>"
@@ -100,7 +102,7 @@ PortletURL portletURL = organizationItemSelectorViewDisplayContext.getPortletURL
 			searchContainer="<%= organizationItemSelectorViewDisplayContext.getSearchContainer() %>"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>
 
 <aui:script use="liferay-search-container">
 	var searchContainer = Liferay.SearchContainer.get(

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/edit_workflow_task.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/edit_workflow_task.jsp
@@ -65,7 +65,7 @@ portletDisplay.setURLBack(backURL);
 renderResponse.setTitle(headerTitle);
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<clay:col
 		className="lfr-asset-column lfr-asset-column-details"
 	>
@@ -291,8 +291,8 @@ renderResponse.setTitle(headerTitle);
 				</liferay-ui:panel>
 			</liferay-ui:panel-container>
 		</aui:fieldset-group>
-	</clay:col>
-</div>
+	</aui:col>
+</clay:container>
 
 <aui:script use="liferay-workflow-tasks">
 	var onTaskClickFn = A.rbind('onTaskClick', Liferay.WorkflowTasks, '');

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/view.jsp
@@ -26,6 +26,8 @@ portletDisplay.setShowBackIcon(false);
 
 <liferay-util:include page="/toolbar.jsp" servletContext="<%= application %>" />
 
-<div class="container-fluid-1280 main-content-body">
+<clay:container
+	className="main-content-body"
+>
 	<%@ include file="/workflow_tasks.jspf" %>
-</div>
+</clay:container>

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -43,11 +43,18 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(title);
 %>
 
+<<<<<<< HEAD
 <div class="container-fluid-1280 main-content-body">
 	<clay:col
 		className="lfr-asset-column lfr-asset-column-details"
 		md="12"
 	>
+=======
+<clay:container
+	className="main-content-body"
+>
+	<div class="col-md-12 lfr-asset-column lfr-asset-column-details">
+>>>>>>> LPS-112628 Replaces div class='container*' with clay:container in JSPs
 		<div class="card-horizontal main-content-card">
 			<div class="panel-body">
 				<c:if test="<%= assetEntry != null %>">
@@ -77,5 +84,10 @@ renderResponse.setTitle(title);
 				</c:if>
 			</div>
 		</div>
+<<<<<<< HEAD
 	</clay:col>
 </div>
+=======
+	</div>
+</clay:container>
+>>>>>>> LPS-112628 Replaces div class='container*' with clay:container in JSPs

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/edit_workflow_definition.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/edit_workflow_definition.jsp
@@ -56,7 +56,7 @@ renderResponse.setTitle((workflowDefinition == null) ? LanguageUtil.get(request,
 
 <c:if test="<%= workflowDefinition != null %>">
 	<liferay-frontend:info-bar>
-		<div class="container-fluid-1280">
+		<clay:container>
 			<div class="info-bar-item">
 				<c:choose>
 					<c:when test="<%= active %>">
@@ -86,7 +86,7 @@ renderResponse.setTitle((workflowDefinition == null) ? LanguageUtil.get(request,
 					</c:otherwise>
 				</c:choose>
 			</span>
-		</div>
+		</clay:container>
 
 		<liferay-frontend:info-bar-buttons>
 			<liferay-frontend:info-bar-sidenav-toggler-button
@@ -104,13 +104,13 @@ renderResponse.setTitle((workflowDefinition == null) ? LanguageUtil.get(request,
 			<div class="sidebar sidebar-light">
 				<div class="tbar-visible-xs">
 					<nav class="component-tbar tbar">
-						<div class="container-fluid">
+						<clay:container>
 							<ul class="tbar-nav">
 								<li class="tbar-item">
 									<aui:icon cssClass="component-action sidenav-close" image="times" markupView="lexicon" url="javascript:;" />
 								</li>
 							</ul>
-						</div>
+						</clay:container>
 					</nav>
 				</div>
 
@@ -190,7 +190,7 @@ renderResponse.setTitle((workflowDefinition == null) ? LanguageUtil.get(request,
 		</div>
 	</c:if>
 
-	<div class="container-fluid-1280">
+	<clay:container>
 		<div class="sidenav-content">
 			<aui:form method="post" name="fm">
 				<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
@@ -280,7 +280,7 @@ renderResponse.setTitle((workflowDefinition == null) ? LanguageUtil.get(request,
 				</aui:button-row>
 			</aui:form>
 		</div>
-	</div>
+	</clay:container>
 </div>
 
 <div class="hide" id="<%= randomNamespace %>titleInputLocalized">

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/view.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/view.jsp
@@ -49,7 +49,9 @@ WorkflowDefinitionSearch workflowDefinitionSearch = new WorkflowDefinitionSearch
 	sortingURL="<%= workflowDefinitionDisplayContext.getSortingURL(request) %>"
 />
 
-<div class="container-fluid-1280 workflow-definition-container">
+<clay:container
+	className="workflow-definition-container"
+>
 	<liferay-ui:error exception="<%= RequiredWorkflowDefinitionException.class %>">
 		<liferay-ui:message arguments="<%= workflowDefinitionDisplayContext.getMessageArguments((RequiredWorkflowDefinitionException)errorException) %>" key="<%= workflowDefinitionDisplayContext.getMessageKey((RequiredWorkflowDefinitionException)errorException) %>" translateArguments="<%= false %>" />
 	</liferay-ui:error>
@@ -116,4 +118,4 @@ WorkflowDefinitionSearch workflowDefinitionSearch = new WorkflowDefinitionSearch
 			searchContainer="<%= workflowDefinitionSearch %>"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/view_workflow_definition.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/view_workflow_definition.jsp
@@ -41,7 +41,7 @@ boolean previewBeforeRestore = WorkflowWebKeys.WORKFLOW_PREVIEW_BEFORE_RESTORE_S
 </liferay-portlet:renderURL>
 
 <liferay-frontend:info-bar>
-	<div class="container-fluid-1280">
+	<clay:container>
 		<c:if test="<%= !previewBeforeRestore %>">
 			<div class="info-bar-item">
 				<c:choose>
@@ -76,7 +76,7 @@ boolean previewBeforeRestore = WorkflowWebKeys.WORKFLOW_PREVIEW_BEFORE_RESTORE_S
 				</c:otherwise>
 			</c:choose>
 		</span>
-	</div>
+	</clay:container>
 </liferay-frontend:info-bar>
 
 <div class="<%= previewBeforeRestore ? "" : "container-fluid-1280" %>" id="container">

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition_link/view.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition_link/view.jsp
@@ -24,7 +24,10 @@ boolean showStripeMessage = workflowDefinitionLinkDisplayContext.showStripeMessa
 
 <liferay-util:include page="/definition_link/management_bar.jsp" servletContext="<%= application %>" />
 
-<div class="container-fluid-1280 workflow-definition-link-container" id="<portlet:namespace />Container">
+<clay:container
+	className="workflow-definition-link-container"
+	id='<%= renderResponse.getNamespace() + "Container" %>'
+>
 	<c:if test="<%= showStripeMessage %>">
 		<clay:alert
 			closeable="true"
@@ -85,4 +88,4 @@ boolean showStripeMessage = workflowDefinitionLinkDisplayContext.showStripeMessa
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/instance/edit_workflow_instance.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/instance/edit_workflow_instance.jsp
@@ -34,7 +34,7 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(workflowInstanceEditDisplayContext.getHeaderTitle());
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<clay:col
 		className="lfr-asset-column lfr-asset-column-details"
 	>
@@ -200,5 +200,5 @@ renderResponse.setTitle(workflowInstanceEditDisplayContext.getHeaderTitle());
 				</liferay-ui:panel>
 			</liferay-ui:panel-container>
 		</aui:fieldset-group>
-	</clay:col>
-</div>
+	</aui:col>
+</clay:container>

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/instance/view.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/instance/view.jsp
@@ -28,6 +28,8 @@ PortletURL portletURL = workflowInstanceViewDisplayContext.getViewPortletURL();
 	<liferay-util:include page="/instance/toolbar.jsp" servletContext="<%= application %>" />
 </aui:form>
 
-<div class="container-fluid-1280 main-content-body workflow-instance-container">
+<clay:container
+	className="main-content-body workflow-instance-container"
+>
 	<%@ include file="/instance/workflow_instance.jspf" %>
-</div>
+</clay:container>

--- a/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/simulation_device.jsp
+++ b/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/simulation_device.jsp
@@ -18,7 +18,9 @@
 
 <div id="<portlet:namespace />simulationDeviceContainer">
 	<div class="list-group-panel">
-		<div class="container-fluid devices">
+		<clay:container
+			className="devices"
+		>
 			<clay:row
 				className="default-devices"
 			>
@@ -59,13 +61,13 @@
 
 			<clay:row
 				className="custom-devices d-lg-flex d-none hide"
-				id="<portlet:namespace />customDeviceContainer"
+				id='<%= renderResponse.getNamespace() + "customDeviceContainer" %>'
 			>
 				<aui:input cssClass="input-sm" inlineField="<%= true %>" label='<%= LanguageUtil.get(request, "height") + " (px):" %>' name="height" size="4" value="600" wrapperCssClass="col-6" />
 
 				<aui:input cssClass="input-sm" inlineField="<%= true %>" label='<%= LanguageUtil.get(request, "width") + " (px):" %>' name="width" size="4" value="600" wrapperCssClass="col-6" />
 			</clay:row>
-		</div>
+		</clay:container>
 	</div>
 </div>
 

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/organizations.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/organizations.jsp
@@ -31,7 +31,10 @@ OrganizationsManagementToolbarDisplayContext organizationsManagementToolbarDispl
 	displayContext="<%= organizationsManagementToolbarDisplayContext %>"
 />
 
-<div class="closed container-fluid-1280 sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
+<clay:container
+	className="closed sidenav-container sidenav-right"
+	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
+>
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/organization/info_panel" var="sidebarPanelURL">
 		<portlet:param name="groupId" value="<%= String.valueOf(siteMembershipsDisplayContext.getGroupId()) %>" />
 	</liferay-portlet:resourceURL>
@@ -79,7 +82,7 @@ OrganizationsManagementToolbarDisplayContext organizationsManagementToolbarDispl
 			</liferay-ui:search-container>
 		</aui:form>
 	</div>
-</div>
+</clay:container>
 
 <portlet:actionURL name="addGroupOrganizations" var="addGroupOrganizationsURL">
 	<portlet:param name="redirect" value="<%= currentURL %>" />

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/preview_membership_request.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/preview_membership_request.jsp
@@ -39,7 +39,7 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(userName);
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:fieldset-group markupView="lexicon">
 		<aui:fieldset>
 			<h4 class="text-default">
@@ -126,4 +126,4 @@ renderResponse.setTitle(userName);
 			</c:choose>
 		</aui:fieldset>
 	</aui:fieldset-group>
-</div>
+</clay:container>

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/users.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/users.jsp
@@ -35,7 +35,10 @@ Role role = usersDisplayContext.getRole();
 
 <liferay-ui:error embed="<%= false %>" exception="<%= RequiredUserException.class %>" message="one-or-more-users-were-not-removed-since-they-belong-to-a-user-group" />
 
-<div class="closed container-fluid-1280 sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
+<clay:container
+	className="closed sidenav-container sidenav-right"
+	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
+>
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/user/info_panel" var="sidebarPanelURL">
 		<portlet:param name="groupId" value="<%= String.valueOf(siteMembershipsDisplayContext.getGroupId()) %>" />
 	</liferay-portlet:resourceURL>
@@ -94,7 +97,7 @@ Role role = usersDisplayContext.getRole();
 			</liferay-ui:search-container>
 		</aui:form>
 	</div>
-</div>
+</clay:container>
 
 <portlet:actionURL name="addGroupUsers" var="addGroupUsersURL">
 	<portlet:param name="redirect" value="<%= currentURL %>" />

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/view_membership_requests.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/view_membership_requests.jsp
@@ -37,7 +37,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "membership-requests"));
 
 <liferay-ui:success key="membershipReplySent" message="your-reply-will-be-sent-to-the-user-by-email" />
 
-<div class="container-fluid-1280">
+</clay:container>
 	<liferay-ui:search-container
 		searchContainer="<%= viewMembershipRequestsDisplayContext.getSiteMembershipSearchContainer() %>"
 	>
@@ -65,4 +65,4 @@ renderResponse.setTitle(LanguageUtil.get(request, "membership-requests"));
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-</div>
+<clay:container>

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/edit_layout_branch.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/edit_layout_branch.jsp
@@ -65,7 +65,10 @@ if (layoutBranch != null) {
 	<liferay-util:param name="navigationName" value="<%= title %>" />
 </liferay-util:include>
 
-<div class="container-fluid-1280" data-namespace="<portlet:namespace />" id="<portlet:namespace /><%= (layoutBranch != null) ? "updateBranch" : "addBranch" %>">
+<clay:container
+	data-namespace="<portlet:namespace />"
+	id='<portlet:namespace /><%= (layoutBranch != null) ? "updateBranch" : "addBranch" %>'
+>
 	<aui:model-context bean="<%= layoutBranch %>" model="<%= LayoutBranch.class %>" />
 
 	<portlet:actionURL name="editLayoutBranch" var="editLayoutBranchURL">
@@ -89,4 +92,4 @@ if (layoutBranch != null) {
 			<aui:button href="<%= redirect %>" value="cancel" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:container>

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/edit_layout_set_branch.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/edit_layout_set_branch.jsp
@@ -63,7 +63,7 @@ if (layoutSetBranch != null) {
 	<liferay-util:param name="navigationName" value="<%= title %>" />
 </liferay-util:include>
 
-<div class="container-fluid-1280 container-view" data-namespace="<portlet:namespace />" id="<portlet:namespace /><%= (layoutSetBranch != null) ? "updateBranch" : "addBranch" %>">
+<div class="container-fluid container-fluid-max-xl container-view"
 	<aui:model-context bean="<%= layoutSetBranch %>" model="<%= LayoutSetBranch.class %>" />
 
 	<portlet:actionURL name="editLayoutSetBranch" var="editLayoutSetBranchURL">

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/merge_layout_set_branch.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/merge_layout_set_branch.jsp
@@ -32,7 +32,7 @@ if (layoutSetBranches.contains(layoutSetBranch)) {
 }
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<div class="site-pages-variation taglib-header">
 		<a class="icon-monospaced list-unstyled portlet-icon-back text-default" href="<%= HtmlUtil.escapeAttribute(redirect) %>" title="<%= HtmlUtil.escapeAttribute(LanguageUtil.get(resourceBundle, "back")) %>">
 			<liferay-ui:icon
@@ -100,7 +100,7 @@ if (layoutSetBranches.contains(layoutSetBranch)) {
 			</liferay-ui:search-container>
 		</aui:form>
 	</div>
-</div>
+</clay:container>
 
 <script>
 	function <portlet:namespace />selectLayoutSetBranch(layoutSetBranchId) {

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view.jsp
@@ -35,7 +35,7 @@ if (liveLayout != null) {
 <c:if test="<%= themeDisplay.isShowStagingIcon() %>">
 	<c:if test="<%= liveGroup != null %>">
 		<nav class="navbar navbar-collapse-absolute navbar-expand navbar-underline navigation-bar navigation-bar-secondary staging-navbar">
-			<div class="container-fluid container-fluid-max-xl">
+			<clay:container>
 				<ul class="navbar-nav">
 					<c:choose>
 						<c:when test="<%= group.isStagingGroup() || group.isStagedRemotely() %>">
@@ -134,12 +134,12 @@ if (liveLayout != null) {
 						markupView="lexicon"
 					/>
 				</button>
-			</div>
+			</clay:container>
 		</nav>
 
 		<c:if test="<%= !layout.isSystem() || layout.isTypeControlPanel() || !Objects.equals(layout.getFriendlyURL(), PropsValues.CONTROL_PANEL_LAYOUT_FRIENDLY_URL) %>">
 			<div class="staging-bar">
-				<div class="container-fluid container-fluid-max-xl">
+				<clay:container>
 					<clay:row>
 						<c:choose>
 							<c:when test="<%= group.isStagingGroup() || group.isStagedRemotely() %>">
@@ -223,7 +223,7 @@ if (liveLayout != null) {
 							</c:otherwise>
 						</c:choose>
 					</clay:row>
-				</div>
+				</clay:container>
 			</div>
 		</c:if>
 	</c:if>

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_branches.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_branches.jsp
@@ -43,7 +43,7 @@ request.setAttribute("view_layout_branches.jsp-currenttLayoutBranchId", String.v
 	<liferay-util:param name="navigationName" value="page-variations" />
 </liferay-util:include>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-ui:success key="pageVariationAdded" message="page-variation-was-added" />
 	<liferay-ui:success key="pageVariationDeleted" message="page-variation-was-deleted" />
 	<liferay-ui:success key="pageVariationUpdated" message="page-variation-was-updated" />
@@ -118,7 +118,7 @@ request.setAttribute("view_layout_branches.jsp-currenttLayoutBranchId", String.v
 			/>
 		</liferay-ui:search-container>
 	</div>
-</div>
+</clay:container>
 
 <aui:script position="inline" use="liferay-staging-branch">
 	Liferay.StagingBar.init({

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revision_status.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revision_status.jsp
@@ -70,7 +70,9 @@ else {
 	<div class="staging-bar-level-3-message">
 		<div class="staging-bar-level-3-message-container">
 			<div class="alert alert-fluid alert-info" role="alert">
-				<div class="container-fluid container-fluid-max-xl staging-alert-container">
+				<clay:container
+					className="staging-alert-container"
+				>
 					<span class="alert-indicator">
 						<svg aria-hidden="true" class="lexicon-icon lexicon-icon-info-circle">
 							<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg#info-circle" />
@@ -78,7 +80,7 @@ else {
 					</span>
 
 					<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(layoutRevision.getName(locale)), layoutSetBranchName} %>" key="the-page-x-is-not-enabled-in-x,-but-is-available-in-other-pages-variations" translateArguments="<%= false %>" />
-				</div>
+				</clay:container>
 			</div>
 		</div>
 	</div>

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revisions.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revisions.jsp
@@ -39,7 +39,7 @@ List<LayoutRevision> rootLayoutRevisions = LayoutRevisionLocalServiceUtil.getChi
 	<liferay-util:param name="navigationName" value="history" />
 </liferay-util:include>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<c:if test="<%= !rootLayoutRevisions.isEmpty() %>">
 		<c:if test="<%= rootLayoutRevisions.size() > 1 %>">
 			<aui:select cssClass="variation-selector" inlineLabel="left" label="" name="variationsSelector">
@@ -169,7 +169,7 @@ List<LayoutRevision> rootLayoutRevisions = LayoutRevisionLocalServiceUtil.getChi
 
 		</div>
 	</c:if>
-</div>
+</clay:container>
 
 <script>
 function <portlet:namespace />selectRevision(

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_set_branches.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_set_branches.jsp
@@ -28,7 +28,7 @@ request.setAttribute("view_layout_set_branches.jsp-currentLayoutSetBranchId", St
 	<liferay-util:param name="navigationName" value="site-pages-variation" />
 </liferay-util:include>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-ui:success key="sitePageVariationAdded" message="site-page-variation-was-added" />
 	<liferay-ui:success key="sitePageVariationDeleted" message="site-page-variation-was-deleted" />
 	<liferay-ui:success key="sitePageVariationMerged" message="site-page-variation-was-merged" />
@@ -97,7 +97,7 @@ request.setAttribute("view_layout_set_branches.jsp-currentLayoutSetBranchId", St
 			/>
 		</liferay-ui:search-container>
 	</div>
-</div>
+</clay:container>
 
 <aui:script use="liferay-staging-branch">
 	Liferay.StagingBar.init({

--- a/modules/apps/user-groups-admin/user-groups-admin-item-selector-web/build.gradle
+++ b/modules/apps/user-groups-admin/user-groups-admin-item-selector-web/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:item-selector:item-selector-api")
 	compileOnly project(":apps:item-selector:item-selector-criteria-api")
 	compileOnly project(":apps:item-selector:item-selector-taglib")

--- a/modules/apps/user-groups-admin/user-groups-admin-item-selector-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/user-groups-admin/user-groups-admin-item-selector-web/src/main/resources/META-INF/resources/init.jsp
@@ -17,6 +17,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/item-selector" prefix="liferay-item-selector" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@

--- a/modules/apps/user-groups-admin/user-groups-admin-item-selector-web/src/main/resources/META-INF/resources/user_group_item_selector.jsp
+++ b/modules/apps/user-groups-admin/user-groups-admin-item-selector-web/src/main/resources/META-INF/resources/user_group_item_selector.jsp
@@ -55,7 +55,9 @@ PortletURL portletURL = userGroupItemSelectorViewDisplayContext.getPortletURL();
 	</liferay-frontend:management-bar-filters>
 </liferay-frontend:management-bar>
 
-<div class="container-fluid-1280" id="<portlet:namespace />userGroupSelectorWrapper">
+<clay:container
+	id='<%= renderResponse.getNamespace() + "userGroupSelectorWrapper" %>'
+>
 	<liferay-ui:search-container
 		id="userGroups"
 		searchContainer="<%= userGroupItemSelectorViewDisplayContext.getSearchContainer() %>"
@@ -94,7 +96,7 @@ PortletURL portletURL = userGroupItemSelectorViewDisplayContext.getPortletURL();
 			searchContainer="<%= userGroupItemSelectorViewDisplayContext.getSearchContainer() %>"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>
 
 <aui:script use="liferay-search-container">
 	var searchContainer = Liferay.SearchContainer.get(

--- a/modules/apps/users-admin/users-admin-item-selector-web/build.gradle
+++ b/modules/apps/users-admin/users-admin-item-selector-web/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:item-selector:item-selector-api")
 	compileOnly project(":apps:item-selector:item-selector-criteria-api")
 	compileOnly project(":apps:item-selector:item-selector-taglib")

--- a/modules/apps/users-admin/users-admin-item-selector-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/users-admin/users-admin-item-selector-web/src/main/resources/META-INF/resources/init.jsp
@@ -17,6 +17,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/item-selector" prefix="liferay-item-selector" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@

--- a/modules/apps/users-admin/users-admin-item-selector-web/src/main/resources/META-INF/resources/user_item_selector.jsp
+++ b/modules/apps/users-admin/users-admin-item-selector-web/src/main/resources/META-INF/resources/user_item_selector.jsp
@@ -55,7 +55,9 @@ PortletURL portletURL = userItemSelectorViewDisplayContext.getPortletURL();
 	</liferay-frontend:management-bar-filters>
 </liferay-frontend:management-bar>
 
-<div class="container-fluid-1280" id="<portlet:namespace />userSelectorWrapper">
+<clay:container
+	id='<%= renderResponse.getNamespace() + "userSelectorWrapper" %>'
+>
 	<liferay-ui:search-container
 		id="users"
 		searchContainer="<%= userItemSelectorViewDisplayContext.getSearchContainer() %>"
@@ -98,7 +100,7 @@ PortletURL portletURL = userItemSelectorViewDisplayContext.getPortletURL();
 			searchContainer="<%= userItemSelectorViewDisplayContext.getSearchContainer() %>"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>
 
 <aui:script use="liferay-search-container">
 	var searchContainer = Liferay.SearchContainer.get('<portlet:namespace />users');

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/item/selector/wiki_pages.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/item/selector/wiki_pages.jsp
@@ -80,7 +80,10 @@ String searchURL = HttpUtil.removeParameter(searchBaseURL.toString(), liferayPor
 	showCreationMenu="<%= false %>"
 />
 
-<div class="container-fluid-1280 lfr-item-viewer" id="<portlet:namespace />wikiPagesSelectorContainer">
+<clay:container
+	className="lfr-item-viewer"
+	id='<%= renderResponse.getNamespace() + "wikiPagesSelectorContainer" %>'
+>
 	<liferay-ui:search-container
 		id="wikiPagesSearchContainer"
 		searchContainer="<%= wikiPagesSearchContainer %>"
@@ -143,7 +146,7 @@ String searchURL = HttpUtil.removeParameter(searchBaseURL.toString(), liferayPor
 			searchContainer="<%= wikiPagesSearchContainer %>"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>
 
 <aui:script use="liferay-search-container">
 	var Util = Liferay.Util;

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/select_version.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/select_version.jsp
@@ -31,7 +31,7 @@ portletURL.setParameter("title", HtmlUtil.unescape(wikiPage.getTitle()));
 portletURL.setParameter("sourceVersion", String.valueOf(sourceVersion));
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form action="<%= portletURL.toString() %>" method="post" name="selectVersionFm">
 		<liferay-ui:search-container
 			id="wikiPageVersionSearchContainer"
@@ -91,7 +91,7 @@ portletURL.setParameter("sourceVersion", String.valueOf(sourceVersion));
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	Liferay.Util.selectEntityHandler(

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view_trash_page_attachments.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view_trash_page_attachments.jsp
@@ -25,7 +25,7 @@ WikiNode node = (WikiNode)request.getAttribute(WikiWebKeys.WIKI_NODE);
 	<portlet:param name="<%= Constants.CMD %>" value="<%= Constants.RESTORE %>" />
 </portlet:actionURL>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-trash:undo
 		portletURL="<%= undoTrashURL %>"
 	/>
@@ -69,4 +69,4 @@ WikiNode node = (WikiNode)request.getAttribute(WikiWebKeys.WIKI_NODE);
 	%>
 
 	<%@ include file="/wiki/attachments_list.jspf" %>
-</div>
+</clay:container>

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/edit_node.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/edit_node.jsp
@@ -31,7 +31,7 @@ renderResponse.setTitle((node == null) ? LanguageUtil.get(request, "new-wiki-nod
 
 <portlet:actionURL name="/wiki/edit_node" var="editNodeURL" />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form action="<%= editNodeURL %>" method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + renderResponse.getNamespace() + "saveNode();" %>'>
 		<aui:input name="<%= Constants.CMD %>" type="hidden" />
 		<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
@@ -70,7 +70,7 @@ renderResponse.setTitle((node == null) ? LanguageUtil.get(request, "new-wiki-nod
 			<aui:button href="<%= redirect %>" type="cancel" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:container>
 
 <aui:script>
 	function <portlet:namespace />saveNode() {

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/import_pages.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/import_pages.jsp
@@ -55,7 +55,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "import-pages"));
 
 <portlet:actionURL name="/wiki/import_pages" var="importPagesURL" />
 
-<div class="container-fluid-1280">
+<clay:container>
 	<aui:form action="<%= importPagesURL %>" enctype="multipart/form-data" method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + renderResponse.getNamespace() + "importPages();" %>'>
 		<aui:input name="<%= Constants.CMD %>" type="hidden" />
 		<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
@@ -92,7 +92,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "import-pages"));
 		id="<%= importProgressId %>"
 		message="importing"
 	/>
-</div>
+</clay:container>
 
 <aui:script>
 	function <portlet:namespace />importPages() {

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/view.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/view.jsp
@@ -92,7 +92,10 @@ WikiNodesManagementToolbarDisplayContext wikiNodesManagementToolbarDisplayContex
 	viewTypeItems="<%= wikiNodesManagementToolbarDisplayContext.getViewTypes() %>"
 />
 
-<div class="closed container-fluid container-fluid-max-xl sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
+<clay:container
+	className="closed sidenav-container sidenav-right"
+	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
+>
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/wiki/node_info_panel" var="sidebarPanelURL" />
 
 	<liferay-frontend:sidebar-panel
@@ -225,7 +228,7 @@ WikiNodesManagementToolbarDisplayContext wikiNodesManagementToolbarDisplayContex
 			</liferay-ui:search-container>
 		</aui:form>
 	</div>
-</div>
+</clay:container>
 
 <script>
 	var deleteNodes = function () {

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/view_node_deleted_attachments.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/view_node_deleted_attachments.jsp
@@ -43,7 +43,7 @@ portletDisplay.setURLBack(backToNodeURL.toString());
 renderResponse.setTitle(LanguageUtil.get(request, "removed-attachments"));
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<portlet:actionURL name="/wiki/edit_node_attachment" var="emptyTrashURL">
 		<portlet:param name="nodeId" value="<%= String.valueOf(node.getPrimaryKey()) %>" />
 	</portlet:actionURL>
@@ -77,4 +77,4 @@ renderResponse.setTitle(LanguageUtil.get(request, "removed-attachments"));
 	%>
 
 	<%@ include file="/wiki/attachments_list.jspf" %>
-</div>
+</clay:container>

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/view_pages.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/view_pages.jsp
@@ -102,7 +102,10 @@ WikiPagesManagementToolbarDisplayContext wikiPagesManagementToolbarDisplayContex
 	viewTypeItems="<%= wikiPagesManagementToolbarDisplayContext.getViewTypes() %>"
 />
 
-<div class="closed container-fluid-1280 sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
+<clay:container
+	className="closed sidenav-container sidenav-right"
+	id='<%= renderResponse.getNamespace() + "infoPanelId" %>'
+>
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/wiki/page_info_panel" var="sidebarPanelURL">
 		<portlet:param name="nodeId" value="<%= String.valueOf(node.getNodeId()) %>" />
 		<portlet:param name="showSidebarHeader" value="<%= Boolean.TRUE.toString() %>" />
@@ -289,7 +292,7 @@ WikiPagesManagementToolbarDisplayContext wikiPagesManagementToolbarDisplayContex
 			</liferay-ui:search-container>
 		</aui:form>
 	</div>
-</div>
+</clay:container>
 
 <script>
 	var deletePages = function () {

--- a/modules/dxp/apps/akismet/akismet-web/build.gradle
+++ b/modules/dxp/apps/akismet/akismet-web/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:application-list:application-list-api")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:message-boards:message-boards-api")
 	compileOnly project(":apps:message-boards:message-boards-service")
 	compileOnly project(":apps:message-boards:message-boards-web")

--- a/modules/dxp/apps/akismet/akismet-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/dxp/apps/akismet/akismet-web/src/main/resources/META-INF/resources/init.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>

--- a/modules/dxp/apps/akismet/akismet-web/src/main/resources/META-INF/resources/view_thread_message.jsp
+++ b/modules/dxp/apps/akismet/akismet-web/src/main/resources/META-INF/resources/view_thread_message.jsp
@@ -32,7 +32,7 @@ if (messageId > 0) {
 
 <a id="<portlet:namespace />message_<%= message.getMessageId() %>"></a>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<div class="spam" style="margin: 10px;">
 		<portlet:actionURL name="markNotSpamMBMessages" var="markAsHamURL" windowState="<%= WindowState.MAXIMIZED.toString() %>">
 			<portlet:param name="redirect" value="<%= portletURL.toString() %>" />
@@ -146,4 +146,4 @@ if (messageId > 0) {
 			</div>
 		</div>
 	</div>
-</div>
+</clay:container>

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/configuration.jsp
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/configuration.jsp
@@ -52,7 +52,7 @@ Map<String, String> emailDefinitionTerms = EmailConfigurationUtil.getEmailDefini
 			<liferay-ui:error key="emailNotificationsSubject" message="please-enter-a-valid-subject" />
 
 			<liferay-ui:section>
-				<div class="container-fluid-1280">
+				<clay:container>
 					<aui:fieldset-group markupView="lexicon">
 						<aui:fieldset>
 							<aui:input cssClass="lfr-input-text-container" label="name" name="preferences--emailFromName--" type="text" value="<%= emailFromName %>" />
@@ -60,11 +60,11 @@ Map<String, String> emailDefinitionTerms = EmailConfigurationUtil.getEmailDefini
 							<aui:input cssClass="lfr-input-text-container" label="address" name="preferences--emailFromAddress--" type="text" value="<%= emailFromAddress %>" />
 						</aui:fieldset>
 					</aui:fieldset-group>
-				</div>
+				</clay:container>
 			</liferay-ui:section>
 
 			<liferay-ui:section>
-				<div class="container-fluid-1280">
+				<clay:container>
 					<aui:fieldset-group markupView="lexicon">
 						<liferay-frontend:email-notification-settings
 							emailBodyLocalizedValuesMap="<%= reportsGroupServiceEmailConfiguration.emailDeliveryBody() %>"
@@ -74,11 +74,11 @@ Map<String, String> emailDefinitionTerms = EmailConfigurationUtil.getEmailDefini
 							emailSubjectLocalizedValuesMap="<%= reportsGroupServiceEmailConfiguration.emailDeliverySubject() %>"
 						/>
 					</aui:fieldset-group>
-				</div>
+				</clay:container>
 			</liferay-ui:section>
 
 			<liferay-ui:section>
-				<div class="container-fluid-1280">
+				<clay:container>
 					<aui:fieldset-group markupView="lexicon">
 						<liferay-frontend:email-notification-settings
 							emailBodyLocalizedValuesMap="<%= reportsGroupServiceEmailConfiguration.emailNotificationsBody() %>"
@@ -88,7 +88,7 @@ Map<String, String> emailDefinitionTerms = EmailConfigurationUtil.getEmailDefini
 							emailSubjectLocalizedValuesMap="<%= reportsGroupServiceEmailConfiguration.emailNotificationsSubject() %>"
 						/>
 					</aui:fieldset-group>
-				</div>
+				</clay:container>
 			</liferay-ui:section>
 		</liferay-ui:tabs>
 	</div>

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/report/requested_report_detail.jsp
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/report/requested_report_detail.jsp
@@ -36,7 +36,7 @@ portletDisplay.setURLBack(searchRequestURL.toString());
 renderResponse.setTitle(definition.getName(locale));
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<c:choose>
 		<c:when test="<%= status.equals(ReportStatus.ERROR.getValue()) %>">
 			<div class="portlet-msg-error">
@@ -226,4 +226,4 @@ renderResponse.setTitle(definition.getName(locale));
 			</liferay-ui:search-container>
 		</aui:fieldset>
 	</aui:fieldset-group>
-</div>
+</clay:container>

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/view.jsp
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/resources/META-INF/resources/admin/view.jsp
@@ -18,7 +18,9 @@
 
 <liferay-util:include page="/admin/toolbar.jsp" servletContext="<%= application %>" />
 
-<div class="container-fluid-1280 main-content-body">
+<clay:container
+	className="main-content-body"
+>
 	<c:choose>
 		<c:when test="<%= hasAddSourcePermission && reportsEngineDisplayContext.isSourcesTabSelected() %>">
 			<liferay-util:include page="/admin/data_source/sources.jsp" servletContext="<%= application %>" />
@@ -30,4 +32,4 @@
 			<liferay-util:include page="/admin/report/entries.jsp" servletContext="<%= application %>" />
 		</c:otherwise>
 	</c:choose>
-</div>
+</clay:container>

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/asset" prefix="liferay-asset" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
@@ -51,7 +52,9 @@ rankingResultContentDisplayBuilder.setRenderResponse(renderResponse);
 RankingResultContentDisplayContext rankingResultContentDisplayContext = rankingResultContentDisplayBuilder.build();
 %>
 
-<div class="container container-no-gutters-sm-down container-view">
+<clay:container
+	className="container-no-gutters-sm-down container-view"
+>
 	<c:choose>
 		<c:when test="<%= rankingResultContentDisplayContext.isVisible() %>">
 			<div class="result-rankings-view-content-container sheet sheet-lg">
@@ -105,4 +108,4 @@ RankingResultContentDisplayContext rankingResultContentDisplayContext = rankingR
 			</div>
 		</c:otherwise>
 	</c:choose>
-</div>
+</clay:container>

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/view.jsp
@@ -18,7 +18,9 @@
 
 <liferay-portlet:renderURL varImpl="searchURL" />
 
-<div class="container-fluid container-fluid-max-xl container-view">
+<clay:container
+	className="container-view"
+>
 	<aui:form action="<%= searchURL %>" method="get" name="fm">
 		<liferay-portlet:renderURLParams varImpl="searchURL" />
 
@@ -108,4 +110,4 @@
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
@@ -85,7 +85,7 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 			<aui:model-context bean="<%= kaleoDefinitionVersion %>" model="<%= KaleoDefinitionVersion.class %>" />
 
 			<liferay-frontend:info-bar>
-				<div class="container-fluid-1280">
+				<clay:container>
 					<c:if test="<%= !isPreviewBeforeRestoreState %>">
 						<div class="info-bar-item">
 							<c:choose>
@@ -120,7 +120,7 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 							</c:otherwise>
 						</c:choose>
 					</span>
-				</div>
+				</clay:container>
 
 				<c:if test="<%= !isPreviewBeforeRestoreState %>">
 					<liferay-frontend:info-bar-buttons>
@@ -140,13 +140,13 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 					<div class="sidebar sidebar-light">
 						<div class="tbar-visible-xs">
 							<nav class="component-tbar tbar">
-								<div class="container-fluid">
+								<clay:container>
 									<ul class="tbar-nav">
 										<li class="tbar-item">
 											<aui:icon cssClass="component-action sidenav-close" image="times" markupView="lexicon" url="javascript:;" />
 										</li>
 									</ul>
-								</div>
+								</clay:container>
 							</nav>
 						</div>
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/view_kaleo_definition_version.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/view_kaleo_definition_version.jsp
@@ -38,7 +38,7 @@ renderResponse.setTitle(kaleoDefinitionVersion.getTitle(locale));
 <aui:model-context bean="<%= kaleoDefinitionVersion %>" model="<%= KaleoDefinitionVersion.class %>" />
 
 <liferay-frontend:info-bar>
-	<div class="container-fluid-1280">
+	<clay:container>
 		<div class="info-bar-item">
 			<c:choose>
 				<c:when test="<%= (kaleoDefinition != null) && kaleoDefinition.isActive() %>">
@@ -68,7 +68,7 @@ renderResponse.setTitle(kaleoDefinitionVersion.getTitle(locale));
 				</c:otherwise>
 			</c:choose>
 		</span>
-	</div>
+	</clay:container>
 </liferay-frontend:info-bar>
 
 <aui:input name="content" type="hidden" value="<%= content %>" />

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/view_workflow_definitions.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/view_workflow_definitions.jsp
@@ -24,7 +24,9 @@ KaleoDefinitionVersionSearch kaleoDefinitionVersionSearch = kaleoDesignerDisplay
 
 <liferay-util:include page="/designer/management_bar.jsp" servletContext="<%= application %>" />
 
-<div class="container-fluid-1280 main-content-body">
+<clay:container
+	className="main-content-body"
+>
 	<liferay-ui:error exception="<%= RequiredWorkflowDefinitionException.class %>">
 		<liferay-ui:message arguments="<%= kaleoDesignerDisplayContext.getMessageArguments((RequiredWorkflowDefinitionException)errorException) %>" key="<%= kaleoDesignerDisplayContext.getMessageKey((RequiredWorkflowDefinitionException)errorException) %>" translateArguments="<%= false %>" />
 	</liferay-ui:error>
@@ -89,4 +91,4 @@ KaleoDefinitionVersionSearch kaleoDefinitionVersionSearch = kaleoDesignerDisplay
 			searchContainer="<%= kaleoDefinitionVersionSearch %>"
 		/>
 	</liferay-ui:search-container>
-</div>
+</clay:container>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/edit_kaleo_process.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/edit_kaleo_process.jsp
@@ -64,9 +64,11 @@ renderResponse.setTitle(title);
 %>
 
 <c:if test="<%= kaleoProcessStarted %>">
-	<div class="alert alert-info container-fluid-1280">
+	<clay:container
+		className="alert alert-info"
+	>
 		<liferay-ui:message key="updating-the-field-set-or-workflow-will-cause-loss-of-data" />
-	</div>
+	</clay:container>
 </c:if>
 
 <portlet:actionURL name="updateKaleoProcess" var="editKaleoProcessURL">

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/edit_record.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/edit_record.jsp
@@ -56,7 +56,9 @@ renderResponse.setTitle((ddlRecord != null) ? LanguageUtil.format(request, "edit
 	<portlet:param name="kaleoProcessId" value="<%= String.valueOf(kaleoProcessId) %>" />
 </portlet:actionURL>
 
-<div class="container-fluid-1280 sidenav-container sidenav-right">
+<clay:container
+	className="sidenav-container sidenav-right"
+>
 	<div class="lfr-form-content">
 		<aui:form action="<%= updateDDLRecordURL %>" cssClass="lfr-dynamic-form" enctype="multipart/form-data" onSubmit='<%= "event.preventDefault(); submitForm(event.target);" %>'>
 			<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
@@ -104,7 +106,7 @@ renderResponse.setTitle((ddlRecord != null) ? LanguageUtil.format(request, "edit
 			</aui:button-row>
 		</aui:form>
 	</div>
-</div>
+</clay:container>
 
 <%
 if (ddlRecord != null) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/edit_request.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/edit_request.jsp
@@ -33,7 +33,9 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(LanguageUtil.format(request, "new-x", kaleoProcess.getName(locale), false));
 %>
 
-<div class="container-fluid-1280 sidenav-container sidenav-right">
+<clay:container
+	className="sidenav-container sidenav-right"
+>
 	<portlet:actionURL name="startWorkflowInstance" var="startWorkflowInstanceURL" />
 
 	<aui:form action="<%= startWorkflowInstanceURL %>" cssClass="lfr-dynamic-form" enctype="multipart/form-data" method="post" name="fm1">
@@ -66,7 +68,7 @@ renderResponse.setTitle(LanguageUtil.format(request, "new-x", kaleoProcess.getNa
 			<aui:button cssClass="btn-lg" href="<%= redirect %>" name="cancelButton" type="cancel" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:container>
 
 <%
 PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.format(request, "add-x", kaleoProcess.getName(locale), false), currentURL);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/init.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/init.jsp
@@ -16,8 +16,6 @@
 
 <%@ include file="/init.jsp" %>
 
-<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %>
-
 <%@ page import="com.liferay.dynamic.data.lists.exception.RecordSetDDMStructureIdException" %><%@
 page import="com.liferay.dynamic.data.lists.exception.RecordSetNameException" %><%@
 page import="com.liferay.dynamic.data.lists.model.DDLRecordConstants" %><%@

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/view.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/view.jsp
@@ -26,7 +26,9 @@ KaleoProcessSearch kaleoProcessSearch = kaleoFormsAdminDisplayContext.getKaleoPr
 
 <liferay-util:include page="/admin/management_bar.jsp" servletContext="<%= application %>" />
 
-<div class="container-fluid-1280" id="<portlet:namespace />formContainer">
+<clay:container
+	id='<%= renderResponse.getNamespace() + "formContainer" %>'
+>
 	<aui:form action="<%= kaleoFormsAdminDisplayContext.getSearchActionURL() %>" method="post" name="fm">
 		<aui:input name="redirect" type="hidden" value="<%= kaleoFormsAdminDisplayContext.getSearchActionURL() %>" />
 		<aui:input name="kaleoProcessIds" type="hidden" />
@@ -90,7 +92,7 @@ KaleoProcessSearch kaleoProcessSearch = kaleoFormsAdminDisplayContext.getKaleoPr
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
 <%@ include file="/admin/export_kaleo_process.jspf" %>
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/view_kaleo_process.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/view_kaleo_process.jsp
@@ -60,7 +60,9 @@ portletURL.setParameter("kaleoProcessId", String.valueOf(kaleoProcess.getKaleoPr
 	sortingURL="<%= kaleoFormsViewRecordsDisplayContext.getSortingURL() %>"
 />
 
-<div class="container-fluid-1280" id="<portlet:namespace />formContainer">
+<clay:container
+	id='<%= renderResponse.getNamespace() + "formContainer" %>'
+>
 	<aui:form action="<%= portletURL.toString() %>" method="post" name="searchContainerForm">
 		<aui:input name="ddlRecordIds" type="hidden" />
 
@@ -146,13 +148,13 @@ portletURL.setParameter("kaleoProcessId", String.valueOf(kaleoProcess.getKaleoPr
 			/>
 		</liferay-ui:search-container>
 	</aui:form>
-</div>
+</clay:container>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-ui:search-paginator
 		searchContainer="<%= kaleoFormsViewRecordsDisplayContext.getSearch() %>"
 	/>
-</div>
+</clay:container>
 
 <%@ include file="/admin/export_kaleo_process.jspf" %>
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/view_record.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/view_record.jsp
@@ -37,7 +37,7 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(LanguageUtil.format(request, "view-x", kaleoProcess.getName(locale), false));
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<c:if test="<%= ddlRecordVersion != null %>">
 		<aui:model-context bean="<%= ddlRecordVersion %>" model="<%= DDLRecordVersion.class %>" />
 
@@ -72,4 +72,4 @@ renderResponse.setTitle(LanguageUtil.format(request, "view-x", kaleoProcess.getN
 			<aui:button cssClass="btn-lg" href="<%= redirect %>" name="cancelButton" type="cancel" />
 		</aui:button-row>
 	</aui:fieldset>
-</div>
+</clay:container>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/asset/full_content.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/asset/full_content.jsp
@@ -26,7 +26,9 @@ DDLRecordVersion ddlRecordVersion = (DDLRecordVersion)request.getAttribute(DDLWe
 KaleoProcessLink kaleoProcessLink = (KaleoProcessLink)request.getAttribute(KaleoFormsWebKeys.KALEO_PROCESS_LINK);
 %>
 
-<div class="container-fluid-1280 main-content-body">
+<clay:container
+	className="main-content-body"
+>
 	<aui:fieldset>
 
 		<%
@@ -53,4 +55,4 @@ KaleoProcessLink kaleoProcessLink = (KaleoProcessLink)request.getAttribute(Kaleo
 			requestedLocale="<%= locale %>"
 		/>
 	</aui:fieldset>
-</div>
+</clay:container>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/init.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/ddm" prefix="liferay-ddm" %><%@
 taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
 taglib uri="http://liferay.com/tld/security" prefix="liferay-security" %><%@

--- a/modules/dxp/apps/saml/saml-web/build.gradle
+++ b/modules/dxp/apps/saml/saml-web/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	compileOnly group: "xml-apis", name: "xml-apis", version: "1.4.01"
 	compileOnly project(":apps:application-list:application-list-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:portal:portal-upgrade-api")
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/edit_identity_provider_connection.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/edit_identity_provider_connection.jsp
@@ -24,12 +24,12 @@ SamlSpIdpConnection samlSpIdpConnection = (SamlSpIdpConnection)request.getAttrib
 long clockSkew = GetterUtil.getLong(request.getAttribute(SamlWebKeys.SAML_CLOCK_SKEW), samlProviderConfiguration.clockSkew());
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-ui:header
 		backURL="<%= redirect %>"
 		title='<%= (samlSpIdpConnection != null) ? samlSpIdpConnection.getName() : "new-identity-provider" %>'
 	/>
-</div>
+</clay:container>
 
 <portlet:actionURL name="/admin/updateIdentityProviderConnection" var="updateIdentityProviderConnectionURL">
 	<portlet:param name="mvcRenderCommandName" value="/admin/edit_identity_provider_connection" />

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/edit_service_provider_connection.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/edit_service_provider_connection.jsp
@@ -24,12 +24,12 @@ SamlIdpSpConnection samlIdpSpConnection = (SamlIdpSpConnection)request.getAttrib
 long assertionLifetime = GetterUtil.getLong(request.getAttribute(SamlWebKeys.SAML_ASSERTION_LIFETIME), samlProviderConfiguration.defaultAssertionLifetime());
 %>
 
-<div class="container-fluid-1280">
+<clay:container>
 	<liferay-ui:header
 		backURL="<%= redirect %>"
 		title='<%= (samlIdpSpConnection != null) ? samlIdpSpConnection.getName() : "new-service-provider" %>'
 	/>
-</div>
+</clay:container>
 
 <portlet:actionURL name="/admin/updateServiceProviderConnection" var="updateServiceProviderConnectionURL">
 	<portlet:param name="mvcRenderCommandName" value="/admin/edit_service_provider_connection" />

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/view.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/view.jsp
@@ -37,7 +37,7 @@ else if (samlProviderConfigurationHelper.isRoleSp()) {
 	names="<%= tabs1Names %>"
 	url="<%= portletURL.toString() %>"
 >
-	<div class="container-fluid-1280">
+	<clay:container>
 		<c:choose>
 			<c:when test='<%= tabs1.equals("general") %>'>
 				<liferay-util:include page="/admin/general.jsp" servletContext="<%= pageContext.getServletContext() %>" />
@@ -55,5 +55,5 @@ else if (samlProviderConfigurationHelper.isRoleSp()) {
 				<liferay-util:include page="/admin/view_service_provider_connections.jsp" servletContext="<%= pageContext.getServletContext() %>" />
 			</c:when>
 		</c:choose>
-	</div>
+	</clay:container>
 </liferay-ui:tabs>

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/init.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>

--- a/modules/sdk/project-templates/project-templates-simulation-panel-entry/src/main/resources/archetype-resources/build.gradle
+++ b/modules/sdk/project-templates/project-templates-simulation-panel-entry/src/main/resources/archetype-resources/build.gradle
@@ -10,4 +10,5 @@ dependencies {
 	compileOnly group: "javax.portlet", name: "portlet-api"
 	compileOnly group: "javax.servlet", name: "javax.servlet-api"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations"
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 }

--- a/modules/sdk/project-templates/project-templates-simulation-panel-entry/src/main/resources/archetype-resources/src/main/resources/META-INF/resources/simulation_panel.jsp
+++ b/modules/sdk/project-templates/project-templates-simulation-panel-entry/src/main/resources/archetype-resources/src/main/resources/META-INF/resources/simulation_panel.jsp
@@ -1,6 +1,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
@@ -17,7 +18,7 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 <div class="list-group-panel" id="<portlet:namespace />simulationOptionsContainer">
 	<p class="text-center"><liferay-ui:message key="simulation-description" /></p>
 
-	<div class="container-fluid default-devices flex-container">
+	<clay:container className="default-devices flex-container">
 		<div class="flex-item-expand d-none d-md-block lfr-device-item selected text-center" data-option="option-1">
 			<aui:icon cssClass="icon icon-monospaced" image="calendar" markupView="lexicon" />
 
@@ -41,7 +42,7 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 			<small><%= LanguageUtil.get(resourceBundle, "option-4") %></small>
 		</div>
-	</div>
+	</clay:container>
 </div>
 
 <aui:script use="aui-base">

--- a/portal-web/docroot/html/portal/layout.jsp
+++ b/portal-web/docroot/html/portal/layout.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/html/portal/init.jsp" %>
 
 <c:if test="<%= SessionErrors.contains(request, NoSuchLayoutException.class) %>">
-	<div class="container pb-3 pt-3">
+	<div class="container-fluid container-fluid-max-xl pb-3 pt-3">
 		<%@ include file="/html/portal/status.jsp" %>
 	</div>
 </c:if>

--- a/portal-web/docroot/html/portal/license.jsp
+++ b/portal-web/docroot/html/portal/license.jsp
@@ -74,7 +74,7 @@ DateFormat dateFormatDateTime = DateFormat.getDateTimeInstance(DateFormat.LONG, 
 dateFormatDateTime.setTimeZone(timeZone);
 %>
 
-<div class="container-fluid container-view">
+<div class="container-fluid container-fluid-max-xl container-view">
 	<h2 class="version-info">
 		<%= versionInfo %>
 	</h2>

--- a/portal-web/docroot/html/portal/setup_wizard.jsp
+++ b/portal-web/docroot/html/portal/setup_wizard.jsp
@@ -19,7 +19,7 @@
 <div class="pt-0" id="wrapper">
 	<header class="mb-4" id="banner">
 		<div class="mb-4 navbar navbar-classic navbar-top py-3">
-			<div class="container">
+			<div class="container-fluid container-fluid-max-xl">
 				<div class="align-items-center d-inline-flex logo">
 
 					<%
@@ -36,7 +36,7 @@
 		</div>
 	</header>
 
-	<div class="container" id="content">
+	<div class="container-fluid container-fluid-max-xl" id="content">
 		<div class="sheet sheet-lg" id="main-content">
 			<h2 class="sheet-title" title="<liferay-ui:message key="basic-configuration" />">
 				<liferay-ui:message key="basic-configuration" />
@@ -473,7 +473,7 @@
 	</div>
 
 	<footer id="footer" role="contentinfo">
-		<div class="container">
+		<div class="container-fluid container-fluid-max-xl">
 			<div class="row">
 				<div class="col-md-12 text-center text-md-left">
 					<liferay-ui:message key="powered-by" /> <a class="text-white" href="http://www.liferay.com" rel="external">Liferay</a>

--- a/portal-web/docroot/html/taglib/aui/nav_bar/lexicon/page.jsp
+++ b/portal-web/docroot/html/taglib/aui/nav_bar/lexicon/page.jsp
@@ -18,7 +18,7 @@
 
 <c:if test="<%= Validator.isContent(bodyContentString) %>">
 	<div class="navbar navbar-default <%= cssClass %>" id="<%= id %>" <%= AUIUtil.buildData(data) %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %>>
-		<div class="container-fluid-1280">
+		<div class="container-fluid container-fluid-max-xl">
 			<c:if test="<%= Validator.isNotNull(dataTarget) %>">
 				<div class="d-block d-sm-none navbar-header">
 					<button class="<%= (navItemCount.getValue() > 1) ? "collapsed" : StringPool.BLANK %> navbar-toggle navbar-toggle-left navbar-toggle-page-name" data-target="<%= (navItemCount.getValue() > 1) ? "#" + dataTarget + "NavbarCollapse" : StringPool.BLANK %>" data-toggle="<%= (navItemCount.getValue() > 1) ? "collapse" : StringPool.BLANK %>" id="<%= namespace %>NavbarBtn" type="button">

--- a/portal-web/docroot/html/taglib/aui/nav_bar/page.jsp
+++ b/portal-web/docroot/html/taglib/aui/nav_bar/page.jsp
@@ -18,7 +18,7 @@
 
 <c:if test="<%= Validator.isContent(bodyContentString) %>">
 	<div class="navbar navbar-default <%= cssClass %>" id="<%= id %>" <%= AUIUtil.buildData(data) %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %>>
-		<div class="container-fluid">
+		<div class="container-fluid container-fluid-max-xl">
 			<c:if test="<%= Validator.isNotNull(responsiveButtons) %>">
 				<div class="navbar-header">
 					<%= responsiveButtons %>

--- a/portal-web/docroot/html/taglib/ui/layout_templates_list/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/layout_templates_list/page.jsp
@@ -22,7 +22,7 @@ String layoutTemplateIdPrefix = (String)request.getAttribute("liferay-ui:layout-
 List<LayoutTemplate> layoutTemplates = (List<LayoutTemplate>)request.getAttribute("liferay-ui:layout-templates-list:layoutTemplates");
 %>
 
-<div class="container-fluid lfr-page-layouts">
+<div class="container-fluid container-fluid-max-xl lfr-page-layouts">
 	<ul class="list-unstyled row">
 
 		<%


### PR DESCRIPTION
**Failing `gradlew clean deploy -a`**

- modules/apps/analytics/analytics-settings-web
- modules/apps/document-library/document-library-web
- modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-taglib
- modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web
- modules/apps/fragment/fragment-web
- modules/apps/item-selector/item-selector-taglib
- modules/apps/item-selector/item-selector-web
- modules/apps/journal/journal-web
- modules/apps/message-boards/message-boards-web
- modules/apps/organizations/organizations-item-selector-web
- modules/apps/portal-workflow/portal-workflow-task-web
- modules/apps/portal-workflow/portal-workflow-web
- modules/apps/product-navigation/product-navigation-simulation-device
- modules/apps/site/site-memberships-web
- modules/apps/staging/staging-bar-web
- modules/apps/user-groups-admin/user-groups-admin-item-selector-web
- modules/apps/users-admin/users-admin-item-selector-web

**Failing `gradlew formatSource` and `gradlew clean deploy -a`**
- modules/apps/wiki/wiki-web
- modules/dxp/apps/akismet/akismet-web
- modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web
- modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web
- modules/dxp/apps/portal-security-audit/portal-security-audit-web
- modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web
- modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web
- modules/dxp/apps/saml/saml-web
- modules/sdk/project-templates/project-templates-simulation-panel-entry
- portal-web/