### PR TITLE
LPS-114029 Replace layout classes with new clay taglibs in dynamic-data-mapping-taglib

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -71,7 +71,7 @@ String orderByType = ParamUtil.getString(request, "orderByType", "asc");
 
 					<aui:fieldset>
 						<div class="lfr-ddl-content">
-							<div class="sheet sheet-lg">
+							<clay:sheet>
 								<liferay-ui:search-container
 									emptyResultsMessage="no-lists-were-found"
 									iteratorURL="<%= configurationRenderURL %>"
@@ -137,7 +137,7 @@ String orderByType = ParamUtil.getString(request, "orderByType", "asc");
 										searchResultCssClass="show-quick-actions-on-hover table table-autofit"
 									/>
 								</liferay-ui:search-container>
-							</div>
+							</clay:sheet>
 						</div>
 					</aui:fieldset>
 				</clay:container-fluid>
@@ -160,7 +160,7 @@ String orderByType = ParamUtil.getString(request, "orderByType", "asc");
 
 						<aui:fieldset>
 							<div class="lfr-ddl-content">
-								<div class="sheet sheet-lg">
+								<clay:sheet>
 									<aui:select helpMessage="select-the-display-template-used-to-diplay-the-list-records" label="display-template" name="preferences--displayDDMTemplateId--">
 										<aui:option label="default" value="<%= 0 %>" />
 
@@ -230,7 +230,7 @@ String orderByType = ParamUtil.getString(request, "orderByType", "asc");
 									<aui:input helpMessage="check-to-display-the-form-entry-view" label="form-view" name="preferences--formView--" type="checkbox" value="<%= formView %>" />
 
 									<aui:input helpMessage="check-to-view-the-list-records-in-a-spreadsheet" label="spreadsheet-view" name="preferences--spreadsheet--" type="checkbox" value="<%= spreadsheet %>" />
-								</div>
+								</clay:sheet>
 							</div>
 						</aui:fieldset>
 					</clay:container-fluid>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-report-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-report-web/src/main/resources/META-INF/resources/view.jsp
@@ -23,13 +23,17 @@ int totalItems = ddmFormReportDisplayContext.getTotalItems();
 <div class="ddm-form-report hide">
 	<div class="ddm-form-report-header">
 		<clay:container-fluid>
-			<div class="align-items-center autofit-row">
+			<clay:content-row
+				className="align-items-center"
+			>
 				<span class="ddm-form-report-header-title text-truncate">
 					<liferay-ui:message arguments="<%= totalItems %>" key="x-entries" />
 				</span>
-			</div>
+			</clay:content-row>
 
-			<div class="align-items-center autofit-row">
+			<clay:content-row
+				className="align-items-center"
+			>
 				<span class="ddm-form-report-header-subtitle text-truncate">
 					<c:choose>
 						<c:when test="<%= totalItems > 0 %>">
@@ -40,7 +44,7 @@ int totalItems = ddmFormReportDisplayContext.getTotalItems();
 						</c:otherwise>
 					</c:choose>
 				</span>
-			</div>
+			</clay:content-row>
 		</clay:container-fluid>
 	</div>
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/configuration.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/configuration.jsp
@@ -52,7 +52,7 @@ DDMFormInstance selFormInstance = DDMFormInstanceServiceUtil.fetchFormInstance(f
 
 			<aui:fieldset>
 				<div class="lfr-form-content">
-					<div class="sheet sheet-lg">
+					<clay:sheet>
 						<liferay-ui:search-container
 							emptyResultsMessage="no-forms-were-found"
 							iteratorURL="<%= configurationRenderURL %>"
@@ -123,7 +123,7 @@ DDMFormInstance selFormInstance = DDMFormInstanceServiceUtil.fetchFormInstance(f
 								searchResultCssClass="show-quick-actions-on-hover table table-autofit"
 							/>
 						</liferay-ui:search-container>
-					</div>
+					</clay:sheet>
 				</div>
 			</aui:fieldset>
 		</clay:container-fluid>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/build.gradle
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:portlet-display-template:portlet-display-template-api")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/init.jsp
@@ -16,7 +16,8 @@
 @generated
 --%>
 
-<%@ taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
+<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
 <%@ page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.json.JSONFactoryUtil" %><%@

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/template_selector/page.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/template_selector/page.jsp
@@ -25,8 +25,12 @@ long ddmTemplateGroupId = PortletDisplayTemplateUtil.getDDMTemplateGroupId(theme
 Group ddmTemplateGroup = GroupLocalServiceUtil.getGroup(ddmTemplateGroupId);
 %>
 
-<div class="autofit-row autofit-row-center">
-	<div class="autofit-col inline-item-before">
+<clay:content-row
+	verticaAlign="center"
+>
+	<clay:content-col
+		className="inline-item-before"
+	>
 		<aui:input id="displayStyleGroupId" name="preferences--displayStyleGroupId--" type="hidden" value="<%= String.valueOf(displayStyleGroupId) %>" />
 
 		<aui:select id="displayStyle" inlineField="<%= true %>" label="<%= HtmlUtil.escape(label) %>" name="preferences--displayStyle--">
@@ -68,10 +72,10 @@ Group ddmTemplateGroup = GroupLocalServiceUtil.getGroup(ddmTemplateGroupId);
 			%>
 
 		</aui:select>
-	</div>
+	</clay:content-col>
 
 	<c:if test="<%= !ddmTemplateGroup.isLayoutPrototype() %>">
-		<div class="autofit-col">
+		<clay:content-col>
 			<liferay-ui:icon
 				icon="<%= HtmlUtil.escapeCSS(icon) %>"
 				id="selectDDMTemplate"
@@ -80,9 +84,9 @@ Group ddmTemplateGroup = GroupLocalServiceUtil.getGroup(ddmTemplateGroupId);
 				message='<%= LanguageUtil.get(request, "manage-templates") %>'
 				url="javascript:;"
 			/>
-		</div>
+		</clay:content-col>
 	</c:if>
-</div>
+</clay:content-row>
 
 <liferay-portlet:renderURL plid="<%= themeDisplay.getPlid() %>" portletName="<%= PortletProviderUtil.getPortletId(DDMTemplate.class.getName(), PortletProvider.Action.VIEW) %>" var="basePortletURL">
 	<portlet:param name="showHeader" value="<%= Boolean.FALSE.toString() %>" />


### PR DESCRIPTION
This is a simple code replacement, we don't expect to see any difference between the old code `<div class="sheet sheet-lg">` and the new one `<clay:sheet>`.

https://github.com/liferay/clay/blob/6244ab8aa35059cc681ead2c1530e6fe320eed2d/packages/clay-layout/src/Sheet.tsx#L81
https://github.com/liferay/clay/blob/6244ab8aa35059cc681ead2c1530e6fe320eed2d/packages/clay-layout/src/Content.tsx#L34