### PR TITLE
LPS-114084 Update test in segments-web

### DIFF
--- a/modules/apps/data-engine/data-engine-taglib/package.json
+++ b/modules/apps/data-engine/data-engine-taglib/package.json
@@ -6,6 +6,7 @@
 		"@clayui/form": "3.8.0",
 		"@clayui/icon": "3.0.5",
 		"@clayui/label": "3.3.0",
+		"@clayui/layout": "3.0.1",
 		"@clayui/link": "3.1.1",
 		"@clayui/list": "3.2.5",
 		"@clayui/loading-indicator": "3.1.0",

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/field-types/FieldType.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/field-types/FieldType.es.js
@@ -13,6 +13,7 @@
  */
 
 import ClayIcon from '@clayui/icon';
+import ClayLayout from '@clayui/layout';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClaySticker from '@clayui/sticker';
 import {ClayTooltipProvider} from '@clayui/tooltip';
@@ -84,32 +85,27 @@ export default (props) => {
 	const fieldIcon = ICONS[icon] ? ICONS[icon] : icon;
 
 	return (
-		<div
-			className={classnames(
-				className,
-				'autofit-row',
-				'autofit-row-center',
-				'field-type',
-				{
-					active,
-					disabled,
-					dragging,
-					loading,
-				}
-			)}
+		<ClayLayout.ContentRow
+			className={classnames(className, 'field-type', {
+				active,
+				disabled,
+				dragging,
+				loading,
+			})}
 			data-field-type-name={name}
 			onClick={onClick && handleOnClick}
 			onDoubleClick={onDoubleClick && handleOnDoubleClick}
 			ref={drag}
+			verticalAlign="center"
 		>
 			{dragAlignment === 'left' && (
-				<div className="autofit-col pl-2 pr-2">
+				<ClayLayout.ContentCol className="pl-2 pr-2">
 					<ClayIcon symbol="drag" />
-				</div>
+				</ClayLayout.ContentCol>
 			)}
 
-			<div
-				className={classnames('autofit-col', 'pr-2', {
+			<ClayLayout.ContentCol
+				className={classnames('pr-2', {
 					'pl-2': dragAlignment === 'right',
 				})}
 			>
@@ -120,9 +116,9 @@ export default (props) => {
 				>
 					<ClayIcon symbol={fieldIcon} />
 				</ClaySticker>
-			</div>
+			</ClayLayout.ContentCol>
 
-			<div className="autofit-col autofit-col-expand pr-2">
+			<ClayLayout.ContentCol className="pr-2" expand>
 				<h4 className="list-group-title text-truncate">
 					<span>{label}</span>
 				</h4>
@@ -132,12 +128,12 @@ export default (props) => {
 						<small>{description}</small>
 					</p>
 				)}
-			</div>
+			</ClayLayout.ContentCol>
 
 			{dragAlignment === 'right' && (
-				<div className="autofit-col pr-2">
+				<ClayLayout.ContentCol className="pr-2">
 					<ClayIcon symbol="drag" />
-				</div>
+				</ClayLayout.ContentCol>
 			)}
 
 			{onDelete && (
@@ -171,6 +167,6 @@ export default (props) => {
 					)}
 				</div>
 			)}
-		</div>
+		</ClayLayout.ContentRow>
 	);
 };

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/rules/RuleList.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/rules/RuleList.es.js
@@ -13,6 +13,7 @@
  */
 
 import ClayButton from '@clayui/button';
+import ClayLayout from '@clayui/layout';
 import React, {useContext} from 'react';
 
 import AppContext from '../../AppContext.es';
@@ -56,7 +57,7 @@ export default ({keywords, toggleRulesEditorVisibility}) => {
 					small
 				/>
 			) : (
-				<div className="autofit-col rule-list">
+				<ClayLayout.ContentCol className="rule-list">
 					<hr />
 					{filteredDataRules.map((rule, index) => (
 						<RuleItem
@@ -67,7 +68,7 @@ export default ({keywords, toggleRulesEditorVisibility}) => {
 							}
 						/>
 					))}
-				</div>
+				</ClayLayout.ContentCol>
 			)}
 		</>
 	);

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/sidebar/Sidebar.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/sidebar/Sidebar.es.js
@@ -12,6 +12,7 @@
  * details.
  */
 
+import ClayLayout from '@clayui/layout';
 import classNames from 'classnames';
 import React, {useState} from 'react';
 
@@ -47,15 +48,15 @@ const SidebarHeader = ({children, className}) => {
 };
 
 const SidebarSearchInput = ({children, onSearch}) => (
-	<div className="autofit-row sidebar-section">
-		<div className="autofit-col autofit-col-expand">
+	<ClayLayout.ContentRow className="sidebar-section">
+		<ClayLayout.ContentCol expand>
 			{onSearch && (
 				<SearchInput onChange={(searchText) => onSearch(searchText)} />
 			)}
-		</div>
+		</ClayLayout.ContentCol>
 
 		{children}
-	</div>
+	</ClayLayout.ContentRow>
 );
 
 const SidebarTabs = ({initialSelectedTab = 0, tabs}) => {
@@ -77,7 +78,7 @@ const SidebarTabs = ({initialSelectedTab = 0, tabs}) => {
 const SidebarTab = ({onTabClick, selectedTab, tabs}) => {
 	return (
 		<nav className="component-tbar tbar">
-			<div className="container-fluid">
+			<ClayLayout.ContainerFluid>
 				<ul className="nav nav-underline" role="tablist">
 					{tabs.map(({label}, index) => (
 						<li className="nav-item" key={index}>
@@ -100,7 +101,7 @@ const SidebarTab = ({onTabClick, selectedTab, tabs}) => {
 						</li>
 					))}
 				</ul>
-			</div>
+			</ClayLayout.ContainerFluid>
 		</nav>
 	);
 };
@@ -116,13 +117,13 @@ const SidebarTabContent = ({children}) => {
 };
 
 const SidebarTitle = ({title}) => (
-	<div className="autofit-row mb-3 sidebar-section">
-		<div className="autofit-col autofit-col-expand">
+	<ClayLayout.ContentRow className="mb-3 sidebar-section">
+		<ClayLayout.ContentCol expand>
 			<div className="component-title">
 				<span className="text-truncate-inline">{title}</span>
 			</div>
-		</div>
-	</div>
+		</ClayLayout.ContentCol>
+	</ClayLayout.ContentRow>
 );
 
 Sidebar.Body = SidebarBody;

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/data-layout-builder/DataLayoutBuilder.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/data-layout-builder/DataLayoutBuilder.es.js
@@ -12,6 +12,7 @@
  * details.
  */
 
+import ClayLayout from '@clayui/layout';
 import classNames from 'classnames';
 import FormBuilderWithLayoutProvider from 'dynamic-data-mapping-form-builder';
 import {PagesVisitor} from 'dynamic-data-mapping-form-renderer';
@@ -428,7 +429,7 @@ class DataLayoutBuilder extends React.Component {
 					}
 				)}
 			>
-				<div className="sheet" ref={this.containerRef} />
+				<ClayLayout.Sheet ref={this.containerRef} />
 			</div>
 		);
 	}

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/plugins/rules-sidebar/components/RulesSidebar.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/plugins/rules-sidebar/components/RulesSidebar.es.js
@@ -14,6 +14,7 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import ClayForm from '@clayui/form';
+import ClayLayout from '@clayui/layout';
 import React, {useState} from 'react';
 
 import RuleEditorModal from '../../../components/rules/RuleEditorModal.es';
@@ -44,23 +45,23 @@ export default function ({title}) {
 			<Sidebar.Header>
 				<Sidebar.Title title={title} />
 
-				<div className="autofit-row sidebar-section">
-					<div className="autofit-col autofit-col-expand">
+				<ClayLayout.ContentRow className="sidebar-section">
+					<ClayLayout.ContentCol expand>
 						<ClayForm onSubmit={(event) => event.preventDefault()}>
 							<Sidebar.SearchInput
 								onSearch={(keywords) => setKeywords(keywords)}
 							/>
 						</ClayForm>
-					</div>
+					</ClayLayout.ContentCol>
 
-					<div className="autofit-col ml-2">
+					<ClayLayout.ContentCol className="ml-2">
 						<ClayButtonWithIcon
 							displayType="primary"
 							onClick={() => toggleRulesEditorVisibility()}
 							symbol="plus"
 						/>
-					</div>
-				</div>
+					</ClayLayout.ContentCol>
+				</ClayLayout.ContentRow>
 			</Sidebar.Header>
 			<Sidebar.Body>
 				<RuleList

--- a/modules/apps/depot/depot-web/package.json
+++ b/modules/apps/depot/depot-web/package.json
@@ -6,6 +6,7 @@
 		"@clayui/form": "3.8.0",
 		"@clayui/icon": "3.0.5",
 		"@clayui/label": "3.3.0",
+		"@clayui/layout": "3.0.1",
 		"@clayui/modal": "3.5.0",
 		"@clayui/table": "3.0.7",
 		"frontend-js-web": "*",

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/LanguageListItemEditable.es.js
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/LanguageListItemEditable.es.js
@@ -16,6 +16,7 @@ import ClayButton from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
+import ClayLayout from '@clayui/layout';
 import ClayTable from '@clayui/table';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
@@ -160,21 +161,25 @@ const LanguageListItem = ({
 			ref={itemRef}
 		>
 			<ClayTable.Cell expanded>
-				<div className="autofit-row autofit-row-center">
-					<div className="autofit-col autofit-padded-no-gutters">
+				<ClayLayout.ContentRow verticalAlign="center">
+					<ClayLayout.ContentCol className="autofit-padded-no-gutters">
 						<div className="language-drag-handler">
 							<ClayIcon symbol="drag" />
 						</div>
-					</div>
-					<div className="align-items-center autofit-col autofit-col-expand autofit-padded-no-gutters flex-row justify-content-start">
+					</ClayLayout.ContentCol>
+
+					<ClayLayout.ContentCol
+						className="align-items-center autofit-padded-no-gutters flex-row justify-content-start"
+						expand
+					>
 						{displayName}
 						{isDefault && (
 							<ClayLabel className="ml-3" displayType="info">
 								{Liferay.Language.get('default')}
 							</ClayLabel>
 						)}
-					</div>
-				</div>
+					</ClayLayout.ContentCol>
+				</ClayLayout.ContentRow>
 			</ClayTable.Cell>
 			<ClayTable.Cell align="right">
 				<ClayDropDown

--- a/modules/apps/headless/headless-discovery/headless-discovery-web/package.json
+++ b/modules/apps/headless/headless-discovery/headless-discovery-web/package.json
@@ -6,6 +6,7 @@
 		"@clayui/form": "3.8.0",
 		"@clayui/icon": "3.0.5",
 		"@clayui/label": "3.3.0",
+		"@clayui/layout": "3.0.1",
 		"@clayui/panel": "3.2.0",
 		"@clayui/tabs": "3.2.0",
 		"frontend-js-react-web": "*",

--- a/modules/apps/headless/headless-discovery/headless-discovery-web/src/main/resources/META-INF/resources/js/APIDisplay.js
+++ b/modules/apps/headless/headless-discovery/headless-discovery-web/src/main/resources/META-INF/resources/js/APIDisplay.js
@@ -12,6 +12,7 @@
  * details.
  */
 
+import ClayLayout from '@clayui/layout';
 import ClayTabs from '@clayui/tabs';
 import React, {useState} from 'react';
 
@@ -46,7 +47,7 @@ const APIDisplay = () => {
 
 	return (
 		<div>
-			<div className="mb-2 sheet-header">
+			<ClayLayout.SheetHeader className="mb-2">
 				<h2 className="mb-2 sheet-title">{path}</h2>
 
 				<div className="align-items-center d-flex sheet-text">
@@ -76,12 +77,12 @@ const APIDisplay = () => {
 				{methodData.description && (
 					<div className="sheet-text">{methodData.description}</div>
 				)}
-			</div>
+			</ClayLayout.SheetHeader>
 
 			<APIForm />
 
 			{apiResponse && (
-				<div className="sheet-section">
+				<ClayLayout.SheetSection>
 					<h3 className="sheet-subtitle">{'Response'}</h3>
 
 					<ClayTabs>
@@ -120,7 +121,7 @@ const APIDisplay = () => {
 							/>
 						</ClayTabs.TabPane>
 					</ClayTabs.Content>
-				</div>
+				</ClayLayout.SheetSection>
 			)}
 		</div>
 	);

--- a/modules/apps/headless/headless-discovery/headless-discovery-web/src/main/resources/META-INF/resources/js/APIFormBase.js
+++ b/modules/apps/headless/headless-discovery/headless-discovery-web/src/main/resources/META-INF/resources/js/APIFormBase.js
@@ -14,6 +14,7 @@
 
 import ClayButton from '@clayui/button';
 import ClayForm from '@clayui/form';
+import ClayLayout from '@clayui/layout';
 import {withFormik} from 'formik';
 import React, {useEffect} from 'react';
 
@@ -64,7 +65,7 @@ const APIFormBase = (props) => {
 
 	return (
 		<form onSubmit={handleSubmit}>
-			<div className="sheet-section">
+			<ClayLayout.SheetSection>
 				{parameters && (
 					<h3 className="sheet-subtitle">
 						{Liferay.Language.get('parameters')}
@@ -117,7 +118,7 @@ const APIFormBase = (props) => {
 						{Liferay.Language.get('execute')}
 					</ClayButton>
 				</ClayForm.Group>
-			</div>
+			</ClayLayout.SheetSection>
 		</form>
 	);
 };

--- a/modules/apps/headless/headless-discovery/headless-discovery-web/src/main/resources/META-INF/resources/js/APIGUI.js
+++ b/modules/apps/headless/headless-discovery/headless-discovery-web/src/main/resources/META-INF/resources/js/APIGUI.js
@@ -15,6 +15,7 @@
 import ClayAlert from '@clayui/alert';
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput, ClaySelect} from '@clayui/form';
+import ClayLayout from '@clayui/layout';
 import ClayModal, {useModal} from '@clayui/modal';
 import GraphiQL from 'graphiql';
 import React, {useCallback, useEffect, useState} from 'react';
@@ -145,7 +146,7 @@ const APIGUI = () => {
 
 	return (
 		<div className="api-gui-root">
-			<div className="container container-fluid">
+			<ClayLayout.ContainerFluid>
 				{showHeaders && (
 					<ClayModal observer={observer} size="lg" status="info">
 						<ClayModal.Header>{'Headers'}</ClayModal.Header>
@@ -229,9 +230,9 @@ const APIGUI = () => {
 					</ClayModal>
 				)}
 
-				<div className="row">
-					<div
-						className="col col-push-3"
+				<ClayLayout.Row>
+					<ClayLayout.Col
+						className="col-push-3"
 						style={{textAlign: 'right'}}
 					>
 						<button
@@ -251,17 +252,20 @@ const APIGUI = () => {
 								? Liferay.Language.get('hide-graphql')
 								: Liferay.Language.get('show-graphql')}
 						</button>
-					</div>
-				</div>
+					</ClayLayout.Col>
+				</ClayLayout.Row>
 
 				{showGraphQL && (
-					<div className="row vh-100">
+					<ClayLayout.Row className="vh-100">
 						<GraphiQL fetcher={graphQLFetcher} />
-					</div>
+					</ClayLayout.Row>
 				)}
 				{!showGraphQL && (
-					<div className="row">
-						<div className="border col col-md-5 overflow-auto p-0 vh-100">
+					<ClayLayout.Row>
+						<ClayLayout.Col
+							className="border overflow-auto p-0 vh-100"
+							md="5"
+						>
 							<ClayForm.Group className="pt-3 px-3">
 								<label
 									className="d-flex justify-content-between"
@@ -357,9 +361,12 @@ const APIGUI = () => {
 									/>
 								)}
 							</div>
-						</div>
+						</ClayLayout.Col>
 
-						<div className="border col col-md-7 overflow-auto p-3 vh-100">
+						<ClayLayout.Col
+							className="border overflow-auto p-3 vh-100"
+							md="7"
+						>
 							{paths && path && method && !showSchemas && (
 								<APIDisplay />
 							)}
@@ -382,10 +389,10 @@ const APIGUI = () => {
 									schemas={schemas}
 								/>
 							)}
-						</div>
-					</div>
+						</ClayLayout.Col>
+					</ClayLayout.Row>
 				)}
-			</div>
+			</ClayLayout.ContainerFluid>
 		</div>
 	);
 };

--- a/modules/apps/segments/segments-web/package.json
+++ b/modules/apps/segments/segments-web/package.json
@@ -5,6 +5,7 @@
 		"@clayui/button": "3.3.1",
 		"@clayui/form": "3.8.0",
 		"@clayui/icon": "3.0.5",
+		"@clayui/layout": "3.0.1",
 		"@clayui/link": "3.1.1",
 		"@clayui/loading-indicator": "3.1.0",
 		"classnames": "2.2.6",

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/ContributorsBuilder.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/ContributorsBuilder.es.js
@@ -13,6 +13,7 @@
  */
 
 import ClayButton from '@clayui/button';
+import ClayLayout from '@clayui/layout';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import getCN from 'classnames';
 import PropTypes from 'prop-types';
@@ -123,9 +124,9 @@ class ContributorBuilder extends React.Component {
 
 					<div className="criteria-builder-section-main">
 						<div className="contributor-container">
-							<div className="container-fluid container-fluid-max-xl">
+							<ClayLayout.ContainerFluid>
 								<div className="content-wrapper">
-									<div className="sheet">
+									<ClayLayout.Sheet>
 										<div className="d-flex flex-wrap justify-content-between mb-4">
 											<h2 className="mb-2 sheet-title">
 												{Liferay.Language.get(
@@ -259,9 +260,9 @@ class ContributorBuilder extends React.Component {
 													</React.Fragment>
 												);
 											})}
-									</div>
+									</ClayLayout.Sheet>
 								</div>
-							</div>
+							</ClayLayout.ContainerFluid>
 						</div>
 					</div>
 				</div>

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/segment_edit/SegmentEdit.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/segment_edit/SegmentEdit.es.js
@@ -13,6 +13,7 @@
  */
 
 import ClayButton from '@clayui/button';
+import ClayLayout from '@clayui/layout';
 import {FieldArray, withFormik} from 'formik';
 import {debounce, fetch, openModal} from 'frontend-js-web';
 import PropTypes from 'prop-types';
@@ -396,7 +397,7 @@ class SegmentEdit extends Component {
 				/>
 
 				<div className="form-header">
-					<div className="container-fluid container-fluid-max-xl form-header-container">
+					<ClayLayout.ContainerFluid className="form-header-container">
 						<div className="form-header-section-left">
 							<FieldArray
 								name="values.name"
@@ -476,7 +477,7 @@ class SegmentEdit extends Component {
 								</div>
 							</div>
 						)}
-					</div>
+					</ClayLayout.ContainerFluid>
 				</div>
 
 				<div className="form-body">

--- a/modules/apps/segments/segments-web/test/js/components/segment_edit/__snapshots__/SegmentEdit.es.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/segment_edit/__snapshots__/SegmentEdit.es.js.snap
@@ -14,7 +14,7 @@ exports[`SegmentEdit renders 1`] = `
       class="form-header"
     >
       <div
-        class="container-fluid container-fluid-max-xl form-header-container"
+        class="form-header-container container-fluid container-fluid-max-xl"
       >
         <div
           class="form-header-section-left"
@@ -118,7 +118,7 @@ exports[`SegmentEdit renders with edit buttons if the user has update permission
       class="form-header"
     >
       <div
-        class="container-fluid container-fluid-max-xl form-header-container"
+        class="form-header-container container-fluid container-fluid-max-xl"
       >
         <div
           class="form-header-section-left"
@@ -302,7 +302,7 @@ exports[`SegmentEdit renders with given values 1`] = `
       class="form-header"
     >
       <div
-        class="container-fluid container-fluid-max-xl form-header-container"
+        class="form-header-container container-fluid container-fluid-max-xl"
       >
         <div
           class="form-header-section-left"
@@ -799,7 +799,7 @@ exports[`SegmentEdit renders without edit buttons if the user does not have upda
       class="form-header"
     >
       <div
-        class="container-fluid container-fluid-max-xl form-header-container"
+        class="form-header-container container-fluid container-fluid-max-xl"
       >
         <div
           class="form-header-section-left"


### PR DESCRIPTION
This is a simple code replacement of the layout classes with the new Clay layout components.

We started this change here https://github.com/jbalsas/liferay-portal/pull/2214 but the `relevant test` was red because we changed the order of classes
<img width="951" alt="Screenshot 2020-06-12 at 11 25 07" src="https://user-images.githubusercontent.com/46778114/84494707-4200fc00-acaa-11ea-9380-b58b450be630.png">

So we had to update the test
<img width="363" alt="Screenshot 2020-06-12 at 11 25 37" src="https://user-images.githubusercontent.com/46778114/84495680-dae44700-acab-11ea-8149-c05923f62d30.png">

