### PR TITLE
LPS-115546 Change style of product-menu because global-app-menu

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/compat/components/_liferay.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/compat/components/_liferay.scss
@@ -12,10 +12,6 @@
 		display: block;
 	}
 
-	.product-menu .panel-group .panel-heading + .panel-collapse.show {
-		border-bottom: 2px solid #65b6f0;
-	}
-
 	.product-menu.sidebar {
 		.sidebar-header {
 			padding-bottom: 0.7rem;

--- a/modules/apps/product-navigation/product-navigation-product-menu-theme-contributor/src/main/resources/META-INF/resources/_variables.scss
+++ b/modules/apps/product-navigation/product-navigation-product-menu-theme-contributor/src/main/resources/META-INF/resources/_variables.scss
@@ -24,7 +24,6 @@ $product-menu-list-group-item-border-width: 0 !default;
 $product-menu-nav-link-active-color: #fff !default;
 $product-menu-nav-link-color: #eeeffa !default;
 
-$product-menu-panel-title-active-border: #65b6f0 !default;
 $product-menu-panel-title-color: #fff !default;
 
 $product-menu-width: 320px !default;

--- a/modules/apps/product-navigation/product-navigation-product-menu-theme-contributor/src/main/resources/META-INF/resources/product_navigation_product_menu.scss
+++ b/modules/apps/product-navigation/product-navigation-product-menu-theme-contributor/src/main/resources/META-INF/resources/product_navigation_product_menu.scss
@@ -307,19 +307,21 @@
 	.panel-group {
 		margin-bottom: 0;
 
-		.panel + .panel {
-			margin-top: 0;
+		.panel {
+			&:last-child {
+				border-bottom-left-radius: 0;
+				border-bottom-right-radius: 0;
+			}
+
+			+ .panel {
+				margin-top: 0;
+			}
 		}
 
 		.panel-heading + .panel-collapse {
 			> .panel-body,
 			> .list-group {
 				border-top-width: 0;
-			}
-
-			&.in,
-			&.collapsing {
-				border-bottom: 2px solid $product-menu-panel-title-active-border;
 			}
 		}
 	}


### PR DESCRIPTION
I've changed the style according to the [Figma file](https://www.figma.com/file/Rj7PUuZJdqpgjtSP09aQYt/LPS-114881-Review-styles-of-site-menu?node-id=71%3A2807)

In order to avoid a little "visual bug" caused by our [Clay Panel Component](https://github.com/liferay/clay/blob/0273c22d1f6a9dfbd22e39f9490d7a9da05e53b7/packages/clay-css/src/scss/components/_panels.scss#L131) I had to add a [special rule](https://github.com/eduardoallegrini/liferay-portal/pull/94/files#diff-960d7c78c730913df07b967756818360R311-R314) for the `product-menu`

<img width="916" alt="Screenshot 2020-06-17 at 15 15 36" src="https://user-images.githubusercontent.com/46778114/84903777-ce4a5f00-b0ae-11ea-8ba4-d1020f7b2d08.png">

**Final Result:**
![image](https://user-images.githubusercontent.com/46778114/84904443-97c11400-b0af-11ea-85d5-ce66c2117be2.png)


/cc @marcoscv-work @jbalsas @victorvalle